### PR TITLE
Added link to the spec repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/DTL-FAIRData/FAIRDataPoint/badge.svg?branch=develop)](https://coveralls.io/github/DTL-FAIRData/FAIRDataPoint?branch=develop)
 
 ### Summary 
-`FAIRDataPoint` is a REST api for creating, storing and servering `FAIR metadata`. The metadata contents are in this api are generated `semi-automatically` according to the [FAIR Data Point software specification](https://dtl-fair.atlassian.net/wiki/display/FDP/FAIR+Data+Point+software+specification) document. In the current version of api we support `GET, POST and PATCH` requests.
+`FAIRDataPoint` is a REST api for creating, storing and servering `FAIR metadata`. The metadata contents are in this api are generated `semi-automatically` according to the [FAIR Data Point software specification](https://github.com/FAIRDataTeam/FAIRDataPoint-Spec) document. In the current version of api we support `GET, POST and PATCH` requests.
 
 #### Deployment machine's requirement
 * JRE 1.8


### PR DESCRIPTION
The original link pointed to the (now archived) confluence page. Right now the spec link points to the master branch of the spec repository. Should it point to develop instead for the develop branch of this repository, and have the master branch of this repository point to the tagged release of the spec (once it's stable)?