### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
Seeing some dependencies are out of date (rdf4j caught my eye mainly, 3.0.0 vs the 3.5/3.6 available now), it's time to automate this. Seeing we are behind on a number of dependencies, upgrading will introduce breaking changes. We need to reserve some time for this.