### PR TITLE
[FDP-566] Use proxy headers if proxied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade Java JDK from 14 to 15
+- Rate limits use forwarded IP by proxy based on config
 
 ### Fixed
 

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/index/AdminController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/index/AdminController.java
@@ -25,6 +25,7 @@ package nl.dtls.fairdatapoint.api.controller.index;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.log4j.Log4j2;
 import nl.dtls.fairdatapoint.entity.index.event.Event;
+import nl.dtls.fairdatapoint.service.UtilityService;
 import nl.dtls.fairdatapoint.service.index.event.EventService;
 import nl.dtls.fairdatapoint.service.index.webhook.WebhookService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,9 @@ import java.util.UUID;
 public class AdminController {
 
     @Autowired
+    private UtilityService utilityService;
+
+    @Autowired
     private EventService eventService;
 
     @Autowired
@@ -51,7 +55,7 @@ public class AdminController {
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void triggerMetadataRetrieve(@RequestParam(required = false) String clientUrl, HttpServletRequest request) {
-        log.info("Received ping from {}", request.getRemoteAddr());
+        log.info("Received ping from {}", utilityService.getRemoteAddr(request));
         final Event event = eventService.acceptAdminTrigger(request, clientUrl);
         webhookService.triggerWebhooks(event);
         eventService.triggerMetadataRetrieval(event);
@@ -62,7 +66,7 @@ public class AdminController {
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void webhookPing(@RequestParam(required = true) UUID webhook, HttpServletRequest request) {
-        log.info("Received webhook {} ping trigger from {}", webhook, request.getRemoteAddr());
+        log.info("Received webhook {} ping trigger from {}", webhook, utilityService.getRemoteAddr(request));
         final Event event = webhookService.handleWebhookPing(request, webhook);
         webhookService.triggerWebhooks(event);
     }

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/index/PingController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/index/PingController.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiOperation;
 import nl.dtls.fairdatapoint.api.dto.index.ping.PingDTO;
 import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositoryException;
 import nl.dtls.fairdatapoint.entity.index.event.Event;
+import nl.dtls.fairdatapoint.service.UtilityService;
 import nl.dtls.fairdatapoint.service.index.event.EventService;
 import nl.dtls.fairdatapoint.service.index.harvester.HarvesterService;
 import nl.dtls.fairdatapoint.service.index.settings.IndexSettingsService;
@@ -56,6 +57,9 @@ public class PingController {
 
     @Autowired
     private IndexSettingsService indexSettingsService;
+    
+    @Autowired
+    private UtilityService utilityService;
 
     @ApiOperation(
             value = "Ping payload with FAIR Data Point info",
@@ -65,7 +69,7 @@ public class PingController {
     @RequestMapping(method = RequestMethod.POST, consumes = "application/json", produces = "application/json")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> receivePing(@RequestBody @Valid PingDTO reqDto, HttpServletRequest request) throws MetadataRepositoryException {
-        logger.info("Received ping from {}", request.getRemoteAddr());
+        logger.info("Received ping from {}", utilityService.getRemoteAddr(request));
         if (indexSettingsService.isPingDenied(reqDto)) {
             logger.info("Received ping is denied");
             return new ResponseEntity<>(HttpStatus.FORBIDDEN);

--- a/src/main/java/nl/dtls/fairdatapoint/api/filter/LoggingFilter.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/filter/LoggingFilter.java
@@ -27,7 +27,9 @@
  */
 package nl.dtls.fairdatapoint.api.filter;
 
+import nl.dtls.fairdatapoint.service.UtilityService;
 import org.apache.logging.log4j.ThreadContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -41,12 +43,15 @@ import java.io.IOException;
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
 
+    @Autowired
+    private UtilityService utilityService;
+
     @Override
     public void doFilterInternal(final HttpServletRequest request,
                                  final HttpServletResponse response, final FilterChain fc)
             throws IOException, ServletException {
 
-        ThreadContext.put("ipAddress", request.getRemoteAddr());
+        ThreadContext.put("ipAddress", utilityService.getRemoteAddr(request));
         ThreadContext.put("responseStatus", String.valueOf(response.getStatus()));
         ThreadContext.put("requestMethod", request.getMethod());
         ThreadContext.put("requestURI", request.getRequestURI());

--- a/src/main/java/nl/dtls/fairdatapoint/config/WebConfig.java
+++ b/src/main/java/nl/dtls/fairdatapoint/config/WebConfig.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.dtls.fairdatapoint.api.converter.ErrorConverter;
 import nl.dtls.fairdatapoint.api.converter.RdfConverter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -88,5 +89,4 @@ public class WebConfig implements WebMvcConfigurer {
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         return mapper;
     }
-
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/UtilityService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/UtilityService.java
@@ -1,0 +1,19 @@
+package nl.dtls.fairdatapoint.service;
+
+import nl.dtls.fairdatapoint.util.HttpUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+public class UtilityService {
+    
+    @Value("${instance.behindProxy:true}")
+    private Boolean behindProxy;
+
+    public String getRemoteAddr(HttpServletRequest request) {
+        return HttpUtil.getClientIpAddress(request, behindProxy);
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/index/event/EventMapper.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/index/event/EventMapper.java
@@ -45,9 +45,9 @@ public class EventMapper {
         );
     }
 
-    public Event toAdminTriggerEvent(HttpServletRequest request, Authentication authentication, String clientUrl) {
+    public Event toAdminTriggerEvent(HttpServletRequest request, Authentication authentication, String clientUrl, String remoteAddr) {
         var adminTrigger = new AdminTrigger();
-        adminTrigger.setRemoteAddr(request.getRemoteAddr());
+        adminTrigger.setRemoteAddr(remoteAddr);
         adminTrigger.setTokenName(authentication.getName());
         adminTrigger.setClientUrl(clientUrl);
         return new Event(VERSION, adminTrigger);

--- a/src/main/java/nl/dtls/fairdatapoint/service/index/event/IncomingPingUtils.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/index/event/IncomingPingUtils.java
@@ -43,9 +43,9 @@ public class IncomingPingUtils {
     @Autowired
     private ObjectMapper objectMapper;
 
-    public Event prepareEvent(PingDTO reqDto, HttpServletRequest request) {
+    public Event prepareEvent(PingDTO reqDto, HttpServletRequest request, String remoteAddr) {
         var incomingPing = new IncomingPing();
-        var ex = new Exchange(ExchangeDirection.INCOMING, request.getRemoteAddr());
+        var ex = new Exchange(ExchangeDirection.INCOMING, remoteAddr);
         incomingPing.setExchange(ex);
 
         ex.getRequest().setHeaders(getHeaders(request));

--- a/src/main/java/nl/dtls/fairdatapoint/service/index/webhook/WebhookMapper.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/index/webhook/WebhookMapper.java
@@ -47,10 +47,10 @@ public class WebhookMapper {
         return new Event(VERSION, webhookTrigger, triggerEvent);
     }
 
-    public Event toPingEvent(HttpServletRequest request, Authentication authentication, UUID webhookUuid) {
+    public Event toPingEvent(HttpServletRequest request, Authentication authentication, UUID webhookUuid, String remoteAddr) {
         var webhookPing = new WebhookPing();
         webhookPing.setWebhookUuid(webhookUuid);
-        webhookPing.setRemoteAddr(request.getRemoteAddr());
+        webhookPing.setRemoteAddr(remoteAddr);
         webhookPing.setTokenName(authentication.getName());
         return new Event(VERSION, webhookPing);
     }

--- a/src/main/java/nl/dtls/fairdatapoint/service/index/webhook/WebhookService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/index/webhook/WebhookService.java
@@ -32,6 +32,7 @@ import nl.dtls.fairdatapoint.entity.index.config.EventsConfig;
 import nl.dtls.fairdatapoint.entity.index.event.Event;
 import nl.dtls.fairdatapoint.entity.index.webhook.Webhook;
 import nl.dtls.fairdatapoint.entity.index.webhook.WebhookEvent;
+import nl.dtls.fairdatapoint.service.UtilityService;
 import nl.dtls.fairdatapoint.service.index.common.RequiredEnabledIndexFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +66,9 @@ public class WebhookService {
 
     @Autowired
     private EventsConfig eventsConfig;
+
+    @Autowired
+    private UtilityService utilityService;
 
     private static final String SECRET_PLACEHOLDER = "*** HIDDEN ***";
 
@@ -106,7 +110,7 @@ public class WebhookService {
     public Event handleWebhookPing(HttpServletRequest request, UUID webhookUuid) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Optional<Webhook> webhook = webhookRepository.findByUuid(webhookUuid);
-        Event event = eventRepository.save(webhookMapper.toPingEvent(request, authentication, webhookUuid));
+        Event event = eventRepository.save(webhookMapper.toPingEvent(request, authentication, webhookUuid, utilityService.getRemoteAddr(request)));
         if (webhook.isEmpty()) {
             throw new ResourceNotFoundException("There is no such webhook: " + webhookUuid);
         }

--- a/src/main/java/nl/dtls/fairdatapoint/util/HttpUtil.java
+++ b/src/main/java/nl/dtls/fairdatapoint/util/HttpUtil.java
@@ -40,16 +40,43 @@ import static nl.dtls.fairdatapoint.util.ValueFactoryHelper.i;
 @Slf4j
 public class HttpUtil {
 
+    private static final String[] IP_HEADER_CANDIDATES = {
+            "X-Forwarded-For",
+            "X-Real-IP",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR"
+    };
+
+    public static String getClientIpAddress(HttpServletRequest request, Boolean behindProxy) {
+        if (behindProxy) {
+            for (String header : IP_HEADER_CANDIDATES) {
+                String ipList = request.getHeader(header);
+                if (ipList != null && ipList.length() != 0 && !"unknown".equalsIgnoreCase(ipList)) {
+                    return ipList.split(",")[0];
+                }
+            }
+        }
+        return request.getRemoteAddr();
+    }
+
     public static String getRequestURL(HttpServletRequest request, String persistentUrl) {
         String urlS = request.getRequestURL().toString();
-        log.info("Original requesed url {}", urlS);
+        log.info("Original requested url {}", urlS);
         try {
             urlS = removeLastSlash(urlS.replace("/expanded", ""));
             persistentUrl = removeLastSlash(persistentUrl);
 
             URL url = new URL(urlS);
             String modifiedUrl = persistentUrl + url.getPath();
-            log.info("Modified requesed url {}", modifiedUrl);
+            log.info("Modified requested url {}", modifiedUrl);
 
             return modifiedUrl;
 

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -59,6 +59,11 @@
       "name": "fdp-index.api.contactName",
       "type": "java.lang.String",
       "description": "Contact name/label for OpenAPI docs"
+    },
+    {
+      "name": "instance.behindProxy",
+      "type": "java.lang.String",
+      "description": "If FDP is running behind reverse HTTP proxy"
     }
   ]
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 instance:
   clientUrl: http://localhost:8080
+  behindProxy: true
 
 spring:
   data:


### PR DESCRIPTION
This solves the issue when FDP Index things that IP of proxy (or proxy of FDP-client) is the origin of pings and there for applies rate limits on all incoming pings together as from one source. Now (if enable as "behind proxy"), it first looks for IP from proxy-related headers, fallback to previously used `getRemoteAddr`.

Related to https://github.com/FAIRDataTeam/FAIRDataPoint-client/pull/37