### PR TITLE
[FDP-544][FDP-567] OpenAPI for generic endpoints and with response types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Migrated API Docs to SpringDoc OpenAPI
+- Generating OpenAPI based on resource definitions
 - Allow to configure multiple ping endpoints
 - Upgrade to Spring Boot 2.4.5
 - Migrated from Mongobee to Mongock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Migrated API Docs to SpringDoc OpenAPI
 - Generating OpenAPI based on resource definitions
+- Explicit content types for responses in OpenAPI
 - Allow to configure multiple ping endpoints
 - Upgrade to Spring Boot 2.4.5
 - Migrated from Mongobee to Mongock

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/apikey/ApiKeyController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/apikey/ApiKeyController.java
@@ -29,11 +29,9 @@ import nl.dtls.fairdatapoint.entity.exception.ResourceNotFoundException;
 import nl.dtls.fairdatapoint.service.apikey.ApiKeyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -47,19 +45,20 @@ public class ApiKeyController {
     @Autowired
     private ApiKeyService apiKeyService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ApiKeyDTO>> getApiKeys() {
         List<ApiKeyDTO> dto = apiKeyService.getAll();
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiKeyDTO> createApiKey() {
         ApiKeyDTO dto = apiKeyService.create();
         return new ResponseEntity<>(dto, HttpStatus.CREATED);
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.DELETE)
+    @DeleteMapping("/{uuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> deleteShape(@PathVariable final String uuid) throws ResourceNotFoundException {
         boolean result = apiKeyService.delete(uuid);
         if (result) {

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/config/ConfigController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/config/ConfigController.java
@@ -27,7 +27,9 @@ import nl.dtls.fairdatapoint.api.dto.config.BootstrapConfigDTO;
 import nl.dtls.fairdatapoint.service.config.ConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,7 +42,7 @@ public class ConfigController {
     @Autowired
     private ConfigService configService;
 
-    @RequestMapping(value = "/bootstrap", method = RequestMethod.GET)
+    @GetMapping(path = "/bootstrap", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<BootstrapConfigDTO> getBootstrapConfig() {
         BootstrapConfigDTO dto = configService.getBootstrapConfig();
         return new ResponseEntity<>(dto, HttpStatus.OK);

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/dashboard/DashboardController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/dashboard/DashboardController.java
@@ -30,9 +30,10 @@ import org.eclipse.rdf4j.model.IRI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
@@ -54,7 +55,7 @@ public class DashboardController {
     @Autowired
     private DashboardService dashboardService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<DashboardItemDTO>> getDashboard(HttpServletRequest request) throws MetadataServiceException {
         IRI uri = i(getRequestURL(request, persistentUrl));
         IRI repositoryUri = removeLastPartOfIRI(uri);

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/exception/ExceptionControllerAdvice.java
@@ -27,6 +27,9 @@
  */
 package nl.dtls.fairdatapoint.api.controller.exception;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import nl.dtls.fairdatapoint.api.dto.error.ErrorDTO;
 import nl.dtls.fairdatapoint.entity.exception.*;
@@ -37,6 +40,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -57,7 +61,15 @@ public class ExceptionControllerAdvice {
 
     @ExceptionHandler({ValidationException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ResponseBody
+    @ResponseBody()
+    @ApiResponse(
+        responseCode = "400",
+        description = "Bad request",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ErrorDTO.class)
+        )
+    )
     public ErrorDTO handleBadRequest(Exception e) {
         log.warn(e.getMessage());
         return new ErrorDTO(HttpStatus.BAD_REQUEST, e.getMessage());
@@ -66,6 +78,14 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler({RdfValidationException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
+    @ApiResponse(
+            responseCode = "400",
+            description = "Bad request",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorDTO.class)
+            )
+    )
     public Model handleBadRequest(RdfValidationException e) {
         Model validationReportModel = e.getModel();
 
@@ -85,6 +105,14 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler({BadCredentialsException.class, UnauthorizedException.class})
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ResponseBody
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorDTO.class)
+            )
+    )
     public ErrorDTO handleUnauthorized(Exception e) {
         log.error(e.getMessage());
         return new ErrorDTO(HttpStatus.UNAUTHORIZED, e.getMessage());
@@ -93,6 +121,14 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler({ForbiddenException.class, AccessDeniedException.class})
     @ResponseStatus(HttpStatus.FORBIDDEN)
     @ResponseBody
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorDTO.class)
+            )
+    )
     public ErrorDTO handleForbidden(Exception e) {
         log.error(e.getMessage());
         return new ErrorDTO(HttpStatus.FORBIDDEN, e.getMessage());
@@ -101,6 +137,14 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(ResourceNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ResponseBody
+    @ApiResponse(
+            responseCode = "404",
+            description = "Resource Not Found",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorDTO.class)
+            )
+    )
     public ErrorDTO handleResourceNotFound(ResourceNotFoundException e) {
         log.error(e.getMessage());
         return new ErrorDTO(HttpStatus.NOT_FOUND, e.getMessage());
@@ -109,6 +153,14 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler({MetadataServiceException.class})
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
+    @ApiResponse(
+            responseCode = "500",
+            description = "Internal Server Error",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorDTO.class)
+            )
+    )
     public ErrorDTO handleInternalServerError(Exception e) {
         log.error(e.getMessage());
         return new ErrorDTO(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/index/IndexEntryController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/index/IndexEntryController.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -44,29 +45,29 @@ public class IndexEntryController {
     @Autowired
     private IndexEntryService service;
 
-    @GetMapping("")
+    @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public Page<IndexEntryDTO> getEntriesPage(Pageable pageable,
                                               @RequestParam(required = false, defaultValue = "") String state) {
         return service.getEntriesPageDTOs(pageable, state);
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.GET)
+    @GetMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Optional<IndexEntryDetailDTO> getEntry(@PathVariable final String uuid) {
         return service.getEntryDetailDTO(uuid);
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.DELETE)
+    @DeleteMapping("/{uuid}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteEntry(@PathVariable final String uuid) {
         service.deleteEntry(uuid);
     }
 
-    @GetMapping("/all")
+    @GetMapping(path = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<IndexEntryDTO> getEntriesAll() {
         return service.getAllEntriesAsDTOs();
     }
 
-    @GetMapping("/info")
+    @GetMapping(path = "/info", produces = MediaType.APPLICATION_JSON_VALUE)
     public IndexEntryInfoDTO getEntriesInfo() {
         return service.getEntriesInfo();
     }

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/index/PingController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/index/PingController.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -86,7 +87,7 @@ public class PingController {
                     @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
             }
     )
-    @RequestMapping(method = RequestMethod.POST, consumes = "application/json", produces = "application/json")
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> receivePing(@RequestBody @Valid PingDTO reqDto, HttpServletRequest request) throws MetadataRepositoryException {
         logger.info("Received ping from {}", utilityService.getRemoteAddr(request));

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/index/SettingsController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/index/SettingsController.java
@@ -27,11 +27,9 @@ import nl.dtls.fairdatapoint.api.dto.index.settings.IndexSettingsDTO;
 import nl.dtls.fairdatapoint.api.dto.index.settings.IndexSettingsUpdateDTO;
 import nl.dtls.fairdatapoint.service.index.settings.IndexSettingsService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -43,19 +41,19 @@ public class SettingsController {
     @Autowired
     private IndexSettingsService indexSettingsService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
     public IndexSettingsDTO getIndexSettings() {
         return indexSettingsService.getCurrentSettings();
     }
 
-    @RequestMapping(method = RequestMethod.PUT)
+    @PutMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
     public IndexSettingsDTO updateIndexSettings(@RequestBody @Valid IndexSettingsUpdateDTO reqDto) {
         return indexSettingsService.updateSettings(reqDto);
     }
 
-    @RequestMapping(method = RequestMethod.DELETE)
+    @DeleteMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
     public IndexSettingsDTO resetIndexSettings() {
         return indexSettingsService.resetSettings();

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/membership/MembershipController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/membership/MembershipController.java
@@ -27,7 +27,9 @@ import nl.dtls.fairdatapoint.api.dto.membership.MembershipDTO;
 import nl.dtls.fairdatapoint.service.membership.MembershipService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,7 +44,7 @@ public class MembershipController {
     @Autowired
     private MembershipService membershipService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<MembershipDTO>> getUsers() {
         List<MembershipDTO> dto = membershipService.getMemberships();
         return new ResponseEntity<>(dto, HttpStatus.OK);

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericController.java
@@ -22,6 +22,7 @@
  */
 package nl.dtls.fairdatapoint.api.controller.metadata;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositoryException;
 import nl.dtls.fairdatapoint.database.rdf.repository.generic.GenericMetadataRepository;
@@ -37,6 +38,7 @@ import nl.dtls.fairdatapoint.service.metadata.enhance.MetadataEnhancer;
 import nl.dtls.fairdatapoint.service.metadata.exception.MetadataServiceException;
 import nl.dtls.fairdatapoint.service.metadata.factory.MetadataServiceFactory;
 import nl.dtls.fairdatapoint.service.metadata.state.MetadataStateService;
+import nl.dtls.fairdatapoint.service.openapi.OpenApiService;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionService;
 import nl.dtls.fairdatapoint.service.shape.ShapeService;
 import nl.dtls.fairdatapoint.service.user.CurrentUserService;
@@ -49,6 +51,7 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -94,18 +97,14 @@ public class GenericController {
     @Autowired
     private GenericMetadataRepository metadataRepository;
 
-    @RequestMapping(
-            value = "**/spec",
-            method = RequestMethod.GET,
-            produces = {"!application/json"})
+    @Operation(hidden = true)
+    @GetMapping(path = "**/spec", produces = {"!application/json"})
     public Model getFormMetadata() {
         return shapeService.getShaclFromShapes();
     }
 
-    @RequestMapping(
-            value = "**/expanded",
-            method = RequestMethod.GET,
-            produces = {"!application/json"})
+    @Operation(hidden = true)
+    @GetMapping(path = "**/expanded", produces = {"!application/json"})
     public Model getMetaDataExpanded(HttpServletRequest request) throws MetadataServiceException {
         // 1. Init
         String uri = getRequestURL(request, persistentUrl);
@@ -141,10 +140,8 @@ public class GenericController {
         return resultRdf;
     }
 
-    @RequestMapping(
-            value = "**",
-            method = RequestMethod.GET,
-            produces = {"!application/json"})
+    @Operation(hidden = true)
+    @GetMapping(path = "**", produces = {"!application/json"})
     public Model getMetaData(HttpServletRequest request) throws MetadataServiceException {
         // 1. Init
         String uri = getRequestURL(request, persistentUrl);
@@ -185,10 +182,8 @@ public class GenericController {
         return resultRdf;
     }
 
-    @RequestMapping(
-            value = "**",
-            method = RequestMethod.POST,
-            produces = {"!application/json"})
+    @Operation(hidden = true)
+    @PostMapping(path = "**", produces = {"!application/json"})
     public ResponseEntity<Model> storeMetaData(HttpServletRequest request,
                                                @RequestBody String reqBody,
                                                @RequestHeader(value = "Content-Type", required = false) String contentType)
@@ -225,10 +220,8 @@ public class GenericController {
                 .body(metadata);
     }
 
-    @RequestMapping(
-            value = "**",
-            method = RequestMethod.PUT,
-            produces = {"!application/json"})
+    @Operation(hidden = true)
+    @PutMapping(path = "**", produces = {"!application/json"})
     public ResponseEntity<Model> updateMetaData(HttpServletRequest request,
                                                 @RequestBody String reqBody,
                                                 @RequestHeader(value = "Content-Type", required = false) String contentType)
@@ -259,7 +252,9 @@ public class GenericController {
                 .ok(metadata);
     }
 
-    @RequestMapping(value = "**", method = RequestMethod.DELETE)
+    @Operation(hidden = true)
+    @DeleteMapping(path = "**")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> deleteMetadata(HttpServletRequest request) throws MetadataServiceException {
         // 1. Init
         String urlPrefix = getResourceNameForDetail(getRequestURL(request, persistentUrl));
@@ -281,10 +276,8 @@ public class GenericController {
         return ResponseEntity.noContent().build();
     }
 
-    @RequestMapping(
-            value = "**/page/{childPrefix}",
-            method = RequestMethod.GET
-    )
+    @Operation(hidden = true)
+    @GetMapping(path = "**/page/{childPrefix}", produces = {"!application/json"})
     public ResponseEntity<Model> getMetaDataChildren(
             @PathVariable final String childPrefix,
             @RequestParam(defaultValue = "0") final int page,

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericMemberController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericMemberController.java
@@ -22,6 +22,7 @@
  */
 package nl.dtls.fairdatapoint.api.controller.metadata;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nl.dtls.fairdatapoint.api.dto.member.MemberCreateDTO;
 import nl.dtls.fairdatapoint.api.dto.member.MemberDTO;
@@ -36,6 +37,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -62,7 +64,8 @@ public class GenericMemberController {
     @Autowired
     private MetadataServiceFactory metadataServiceFactory;
 
-    @RequestMapping(value = "**/members", method = RequestMethod.GET)
+    @Operation(hidden = true)
+    @GetMapping(path = "**/members", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<MemberDTO>> getMembers(HttpServletRequest request)
             throws ResourceNotFoundException, MetadataServiceException {
         // 1. Init
@@ -80,7 +83,8 @@ public class GenericMemberController {
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "**/members/{userUuid}", method = RequestMethod.PUT)
+    @Operation(hidden = true)
+    @PutMapping(path = "**/members/{userUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<MemberDTO> putMember(@PathVariable final String userUuid,
                                                HttpServletRequest request,
                                                @RequestBody @Valid MemberCreateDTO reqBody)
@@ -101,7 +105,9 @@ public class GenericMemberController {
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "**/members/{userUuid}", method = RequestMethod.DELETE)
+    @Operation(hidden = true)
+    @DeleteMapping(path = "**/members/{userUuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> deleteMember(@PathVariable final String userUuid, HttpServletRequest request)
             throws ResourceNotFoundException, MetadataServiceException {
         // 1. Init

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericMetaController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericMetaController.java
@@ -22,6 +22,7 @@
  */
 package nl.dtls.fairdatapoint.api.controller.metadata;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nl.dtls.fairdatapoint.api.dto.member.MemberDTO;
 import nl.dtls.fairdatapoint.api.dto.metadata.MetaDTO;
@@ -73,7 +74,8 @@ public class GenericMetaController {
     @Autowired
     private ResourceDefinitionService resourceDefinitionService;
 
-    @RequestMapping(value = "**/meta", method = RequestMethod.GET)
+    @Operation(hidden = true)
+    @RequestMapping(path = "**/meta", method = RequestMethod.GET)
     public MetaDTO getMeta(HttpServletRequest request) throws MetadataServiceException {
         // 1. Init
         String urlPrefix = getResourceNameForList(getRequestURL(request, persistentUrl));
@@ -98,7 +100,8 @@ public class GenericMetaController {
         return new MetaDTO(member, state);
     }
 
-    @RequestMapping(value = "**/meta/state", method = RequestMethod.PUT)
+    @Operation(hidden = true)
+    @RequestMapping(path = "**/meta/state", method = RequestMethod.PUT)
     public MetaStateChangeDTO putMetaState(HttpServletRequest request, @RequestBody @Valid MetaStateChangeDTO reqDto) throws MetadataServiceException {
         // 1. Init
         String urlPrefix = getResourceNameForList(getRequestURL(request, persistentUrl));

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/profile/ProfileController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/profile/ProfileController.java
@@ -23,6 +23,7 @@
 package nl.dtls.fairdatapoint.api.controller.profile;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import nl.dtls.fairdatapoint.config.ConverterConfig;
 import nl.dtls.fairdatapoint.entity.exception.ResourceNotFoundException;
 import nl.dtls.fairdatapoint.service.profile.ProfileService;
 import org.eclipse.rdf4j.model.IRI;
@@ -52,7 +53,16 @@ public class ProfileController {
     @Autowired
     private ProfileService profileService;
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.GET, produces = {"!application/json"})
+    @GetMapping(path = "/{uuid}", produces = {
+            "text/turtle",
+            "application/x-turtle",
+            "text/n3",
+            "text/rdf+n3",
+            "application/ld+json",
+            "application/rdf+xml",
+            "application/xml",
+            "text/xml",
+    })
     public ResponseEntity<Model> getShapeContent(HttpServletRequest request, @PathVariable final String uuid)
             throws ResourceNotFoundException {
         IRI uri = i(getRequestURL(request, persistentUrl));

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/resource/ResourceDefinitionController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/resource/ResourceDefinitionController.java
@@ -29,6 +29,7 @@ import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.*;
@@ -47,19 +48,19 @@ public class ResourceDefinitionController {
     @Autowired
     private ResourceDefinitionService resourceDefinitionService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ResourceDefinition>> getResourceDefinitions() {
         List<ResourceDefinition> dto = resourceDefinitionService.getAll();
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResourceDefinition> createResourceDefinitions(@RequestBody @Valid ResourceDefinitionChangeDTO reqDto) throws BindException {
         ResourceDefinition dto = resourceDefinitionService.create(reqDto);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.GET)
+    @GetMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResourceDefinition> getResourceDefinition(@PathVariable final String uuid)
             throws ResourceNotFoundException {
         Optional<ResourceDefinition> oDto = resourceDefinitionService.getByUuid(uuid);
@@ -70,7 +71,7 @@ public class ResourceDefinitionController {
         }
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.PUT)
+    @PutMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResourceDefinition> putResourceDefinitions(@PathVariable final String uuid,
                                                                      @RequestBody @Valid ResourceDefinitionChangeDTO reqDto)
             throws ResourceNotFoundException, BindException {
@@ -82,7 +83,8 @@ public class ResourceDefinitionController {
         }
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.DELETE)
+    @DeleteMapping(path = "/{uuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> deleteResourceDefinitions(@PathVariable final String uuid)
             throws ResourceNotFoundException {
         boolean result = resourceDefinitionService.deleteByUuid(uuid);

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -28,6 +28,7 @@ import nl.dtls.fairdatapoint.api.dto.search.SearchResultDTO;
 import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositoryException;
 import nl.dtls.fairdatapoint.service.search.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,7 +46,7 @@ public class SearchController {
     @Autowired
     private SearchService searchService;
 
-    @PostMapping
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<SearchResultDTO>> search(@RequestBody @Valid SearchQueryDTO reqDto) throws MetadataRepositoryException {
         return ResponseEntity.ok(searchService.search(reqDto));
     }

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/shape/ShapeController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/shape/ShapeController.java
@@ -31,6 +31,7 @@ import nl.dtls.fairdatapoint.service.shape.ShapeService;
 import org.eclipse.rdf4j.model.Model;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -49,40 +50,40 @@ public class ShapeController {
     @Autowired
     private ShapeService shapeService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ShapeDTO>> getShapes() {
         List<ShapeDTO> dto = shapeService.getShapes();
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/public", method = RequestMethod.GET)
+    @GetMapping(path = "/public", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ShapeDTO>> getPublishedShapes() {
         List<ShapeDTO> dto = shapeService.getPublishedShapes();
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @RequestMapping(value = "/import", method = RequestMethod.GET)
+    @GetMapping(path = "/import", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ShapeRemoteDTO>> getImportableShapes(@RequestParam(name = "from") String fdpUrl) {
         List<ShapeRemoteDTO> dto = shapeService.getRemoteShapes(fdpUrl);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @RequestMapping(value = "/import", method = RequestMethod.POST)
+    @PostMapping(path = "/import", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<ShapeDTO>> importShapes(@RequestBody @Valid List<ShapeRemoteDTO> reqDtos) {
         List<ShapeDTO> dto = shapeService.importShapes(reqDtos);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ShapeDTO> createShape(@RequestBody @Valid ShapeChangeDTO reqDto) {
         ShapeDTO dto = shapeService.createShape(reqDto);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.GET, produces = {"application/json"})
+    @GetMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ShapeDTO> getShape(@PathVariable final String uuid)
             throws ResourceNotFoundException {
         Optional<ShapeDTO> oDto = shapeService.getShapeByUuid(uuid);
@@ -93,8 +94,16 @@ public class ShapeController {
         }
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.GET, produces = {"!application/json"})
+    @GetMapping(path = "/{uuid}", produces = {
+            "text/turtle",
+            "application/x-turtle",
+            "text/n3",
+            "text/rdf+n3",
+            "application/ld+json",
+            "application/rdf+xml",
+            "application/xml",
+            "text/xml",
+    })
     public ResponseEntity<Model> getShapeContent(@PathVariable final String uuid)
             throws ResourceNotFoundException {
         Optional<Model> oDto = shapeService.getShapeContentByUuid(uuid);
@@ -106,7 +115,7 @@ public class ShapeController {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.PUT)
+    @PutMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ShapeDTO> putShape(@PathVariable final String uuid,
                                              @RequestBody @Valid ShapeChangeDTO reqDto) throws ResourceNotFoundException {
         Optional<ShapeDTO> oDto = shapeService.updateShape(uuid, reqDto);
@@ -118,7 +127,8 @@ public class ShapeController {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.DELETE)
+    @DeleteMapping("/{uuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> deleteShape(@PathVariable final String uuid)
             throws ResourceNotFoundException {
         boolean result = shapeService.deleteShape(uuid);

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/token/TokenController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/token/TokenController.java
@@ -28,14 +28,12 @@ import nl.dtls.fairdatapoint.api.dto.auth.TokenDTO;
 import nl.dtls.fairdatapoint.service.jwt.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -47,7 +45,7 @@ public class TokenController {
     @Autowired
     private JwtService jwtService;
 
-    @PostMapping
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<TokenDTO> generateToken(@RequestBody @Valid AuthDTO reqDto) {
         try {
             String token = jwtService.createToken(reqDto);

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/user/UserController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/user/UserController.java
@@ -30,6 +30,7 @@ import nl.dtls.fairdatapoint.service.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -47,20 +48,20 @@ public class UserController {
     @Autowired
     private UserService userService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<UserDTO>> getUsers() {
         List<UserDTO> dto = userService.getUsers();
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> createUser(@RequestBody @Valid UserCreateDTO reqDto) {
         UserDTO dto = userService.createUser(reqDto);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     @Tag(name = "Authentication and Authorization")
-    @RequestMapping(value = "/current", method = RequestMethod.GET)
+    @GetMapping(path = "/current", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> getUserCurrent() throws ResourceNotFoundException {
         Optional<UserDTO> oDto = userService.getCurrentUser();
         if (oDto.isPresent()) {
@@ -70,7 +71,7 @@ public class UserController {
         }
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.GET)
+    @GetMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> getUser(@PathVariable final String uuid) throws ResourceNotFoundException {
         Optional<UserDTO> oDto = userService.getUserByUuid(uuid);
         if (oDto.isPresent()) {
@@ -80,7 +81,7 @@ public class UserController {
         }
     }
 
-    @RequestMapping(value = "/current", method = RequestMethod.PUT)
+    @PutMapping(path = "/current", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> putUserCurrent(@RequestBody @Valid UserProfileChangeDTO reqDto) throws ResourceNotFoundException {
         Optional<UserDTO> oDto = userService.updateCurrentUser(reqDto);
         if (oDto.isPresent()) {
@@ -90,7 +91,7 @@ public class UserController {
         }
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.PUT)
+    @PutMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> putUser(@PathVariable final String uuid,
                                            @RequestBody @Valid UserChangeDTO reqDto) throws ResourceNotFoundException {
         Optional<UserDTO> oDto = userService.updateUser(uuid, reqDto);
@@ -101,7 +102,7 @@ public class UserController {
         }
     }
 
-    @RequestMapping(value = "/current/password", method = RequestMethod.PUT)
+    @PutMapping(path = "/current/password", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> putUserCurrentPassword(@RequestBody @Valid UserPasswordDTO reqDto)
             throws ResourceNotFoundException {
         Optional<UserDTO> oDto = userService.updatePasswordForCurrentUser(reqDto);
@@ -112,7 +113,7 @@ public class UserController {
         }
     }
 
-    @RequestMapping(value = "/{uuid}/password", method = RequestMethod.PUT)
+    @PutMapping(path = "/{uuid}/password", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> putUserPassword(@PathVariable final String uuid,
                                                    @RequestBody @Valid UserPasswordDTO reqDto) throws ResourceNotFoundException {
         Optional<UserDTO> oDto = userService.updatePassword(uuid, reqDto);
@@ -123,8 +124,9 @@ public class UserController {
         }
     }
 
-    @RequestMapping(value = "/{uuid}", method = RequestMethod.DELETE)
-    public HttpEntity deleteUser(@PathVariable final String uuid)
+    @DeleteMapping("/{uuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> deleteUser(@PathVariable final String uuid)
             throws ResourceNotFoundException {
         boolean result = userService.deleteUser(uuid);
         if (result) {

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/metadata/MetaDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/metadata/MetaDTO.java
@@ -22,12 +22,14 @@
  */
 package nl.dtls.fairdatapoint.api.dto.metadata;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import nl.dtls.fairdatapoint.api.dto.member.MemberDTO;
 
+@Schema(name = "MetaDTO")
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/nl/dtls/fairdatapoint/config/OpenApiConfig.java
+++ b/src/main/java/nl/dtls/fairdatapoint/config/OpenApiConfig.java
@@ -24,6 +24,7 @@ package nl.dtls.fairdatapoint.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
@@ -31,6 +32,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
+import nl.dtls.fairdatapoint.service.openapi.OpenApiTagsUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.BuildProperties;
@@ -39,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,13 +77,16 @@ public class OpenApiConfig {
                         )
                 )
                 .addSecurityItem(new SecurityRequirement().addList("bearer-jwt", Arrays.asList("read", "write")))
-                .tags(Stream.of("Metadata", "Metadata Model", "Client", "Index", "Authentication and Authorization", "User Management").map(name -> new Tag().name(name)).collect(Collectors.toList()));
+                .tags(OpenApiTagsUtils.STATIC_TAGS);
         if (contactUrl != null) {
             openAPI.getInfo().contact(new Contact().url(contactUrl).name(contactName).email(contactName));
         }
         if (serverUrl != null) {
             openAPI.servers(Collections.singletonList(new Server().url(serverUrl)));
         }
+        openAPI.setExtensions(new LinkedHashMap<>());
+        openAPI.getExtensions().put("fdpGenericPaths", new Paths());
+        openAPI.setPaths(new Paths());
         return openAPI;
     }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiGenerator.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiGenerator.java
@@ -1,0 +1,492 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package nl.dtls.fairdatapoint.service.openapi;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.tags.Tag;
+import nl.dtls.fairdatapoint.api.dto.error.ErrorDTO;
+import nl.dtls.fairdatapoint.api.dto.member.MemberCreateDTO;
+import nl.dtls.fairdatapoint.api.dto.member.MemberDTO;
+import nl.dtls.fairdatapoint.api.dto.metadata.MetaDTO;
+import nl.dtls.fairdatapoint.api.dto.metadata.MetaStateChangeDTO;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+public class OpenApiGenerator {
+
+    public static final String FDP_TAG_PRIORITY = "FDP-TP";
+
+    public static final String TAG_PREFIX = "Metadata: ";
+
+    private static final Schema<String> SCHEMA_STRING = new Schema<String>().type("string");
+
+    private static final Schema<String> SCHEMA_ERROR = new Schema<ErrorDTO>().$ref("#/components/schemas/ErrorDTO");
+
+    private static final Schema<String> SCHEMA_META = new Schema<MetaDTO>().$ref("#/components/schemas/MetaDTO");
+
+    private static final Schema<String> SCHEMA_META_STATE_CHANGE = new Schema<MetaStateChangeDTO>().$ref("#/components/schemas/MetaStateChangeDTO");
+
+    private static final Schema<String> SCHEMA_MEMBER = new Schema<MemberDTO>().$ref("#/components/schemas/MemberDTO");
+
+    private static final ArraySchema SCHEMA_MEMBERS = new ArraySchema().items(SCHEMA_MEMBER);
+
+    private static final Schema<String> SCHEMA_MEMBER_CREATE = new Schema<MemberCreateDTO>().$ref("#/components/schemas/MemberDTO");
+
+    private static final Content CONTENT_RDF = new Content()
+            .addMediaType("text/turtle", new MediaType().schema(SCHEMA_STRING))
+            .addMediaType("application/ld+json", new MediaType().schema(SCHEMA_STRING))
+            .addMediaType("application/rdf+xml", new MediaType().schema(SCHEMA_STRING))
+            .addMediaType("text/n3", new MediaType().schema(SCHEMA_STRING));
+
+    private static final Content CONTENT_ERROR = new Content()
+            .addMediaType("text/plain", new MediaType().schema(SCHEMA_STRING))
+            .addMediaType("application/json", new MediaType().schema(SCHEMA_ERROR));
+
+    private static final Content CONTENT_META_STATE_CHANGE = new Content()
+            .addMediaType("application/json", new MediaType().schema(SCHEMA_META_STATE_CHANGE));
+
+    private static final ApiResponse RESPONSE_BAD_REQUEST = new ApiResponse()
+            .description("Bad Request")
+            .content(CONTENT_ERROR);
+
+    private static final ApiResponse RESPONSE_FORBIDDEN = new ApiResponse()
+            .description("Forbidden")
+            .content(CONTENT_ERROR);
+
+    private static final ApiResponse RESPONSE_UNAUTHORIZED = new ApiResponse()
+            .description("Unauthorized")
+            .content(CONTENT_ERROR);
+
+    private static final ApiResponse RESPONSE_NOT_FOUND = new ApiResponse()
+            .description("Not Found")
+            .content(CONTENT_ERROR);
+
+    private static final ApiResponse RESPONSE_NO_CONTENT = new ApiResponse()
+            .description("No Content");
+
+    private static final ApiResponse RESPONSE_INTERNAL_SERVER_ERROR = new ApiResponse()
+            .description("Internal Server Error")
+            .content(CONTENT_ERROR);
+
+    private static final ApiResponse RESPONSE_OK_RDF = new ApiResponse()
+            .description("OK")
+            .content(CONTENT_RDF);
+
+    private static final ApiResponses RESPONSES_RDF = new ApiResponses()
+            .addApiResponse("200", RESPONSE_OK_RDF)
+            .addApiResponse("400", RESPONSE_BAD_REQUEST)
+            .addApiResponse("401", RESPONSE_UNAUTHORIZED)
+            .addApiResponse("403", RESPONSE_FORBIDDEN)
+            .addApiResponse("404", RESPONSE_NOT_FOUND)
+            .addApiResponse("500", RESPONSE_INTERNAL_SERVER_ERROR);
+
+    private static final ApiResponses RESPONSES_DELETE = new ApiResponses()
+            .addApiResponse("204", RESPONSE_NO_CONTENT)
+            .addApiResponse("400", RESPONSE_BAD_REQUEST)
+            .addApiResponse("401", RESPONSE_UNAUTHORIZED)
+            .addApiResponse("403", RESPONSE_FORBIDDEN)
+            .addApiResponse("404", RESPONSE_NOT_FOUND)
+            .addApiResponse("500", RESPONSE_INTERNAL_SERVER_ERROR);
+
+    private static final ApiResponses RESPONSES_META = new ApiResponses()
+            .addApiResponse("200", new ApiResponse()
+                    .description("OK")
+                    .content(new Content()
+                            .addMediaType("application/json", new MediaType().schema(SCHEMA_META)))
+            )
+            .addApiResponse("400", RESPONSE_BAD_REQUEST)
+            .addApiResponse("401", RESPONSE_UNAUTHORIZED)
+            .addApiResponse("403", RESPONSE_FORBIDDEN)
+            .addApiResponse("404", RESPONSE_NOT_FOUND)
+            .addApiResponse("500", RESPONSE_INTERNAL_SERVER_ERROR);
+
+    private static final ApiResponses RESPONSES_META_STATE = new ApiResponses()
+            .addApiResponse("200", new ApiResponse()
+                    .description("OK")
+                    .content(CONTENT_META_STATE_CHANGE)
+            )
+            .addApiResponse("400", RESPONSE_BAD_REQUEST)
+            .addApiResponse("401", RESPONSE_UNAUTHORIZED)
+            .addApiResponse("403", RESPONSE_FORBIDDEN)
+            .addApiResponse("404", RESPONSE_NOT_FOUND)
+            .addApiResponse("500", RESPONSE_INTERNAL_SERVER_ERROR);
+
+    private static final ApiResponses RESPONSES_MEMBERS = new ApiResponses()
+            .addApiResponse("200", new ApiResponse()
+                    .description("OK")
+                    .content(new Content()
+                            .addMediaType("application/json", new MediaType().schema(SCHEMA_MEMBERS)))
+            )
+            .addApiResponse("400", RESPONSE_BAD_REQUEST)
+            .addApiResponse("401", RESPONSE_UNAUTHORIZED)
+            .addApiResponse("403", RESPONSE_FORBIDDEN)
+            .addApiResponse("404", RESPONSE_NOT_FOUND)
+            .addApiResponse("500", RESPONSE_INTERNAL_SERVER_ERROR);
+
+    private static final ApiResponses RESPONSES_MEMBER = new ApiResponses()
+            .addApiResponse("200", new ApiResponse()
+                    .description("OK")
+                    .content(new Content()
+                            .addMediaType("application/json", new MediaType().schema(SCHEMA_MEMBER)))
+            )
+            .addApiResponse("400", RESPONSE_BAD_REQUEST)
+            .addApiResponse("401", RESPONSE_UNAUTHORIZED)
+            .addApiResponse("403", RESPONSE_FORBIDDEN)
+            .addApiResponse("404", RESPONSE_NOT_FOUND)
+            .addApiResponse("500", RESPONSE_INTERNAL_SERVER_ERROR);
+
+    private static final RequestBody BODY_META_STATE = new RequestBody()
+            .description("New state")
+            .content(CONTENT_META_STATE_CHANGE)
+            .required(true);
+
+    private static final RequestBody BODY_MEMBERSHIP = new RequestBody()
+            .description("New membership")
+            .content(new Content().addMediaType("application/json", new MediaType().schema(SCHEMA_MEMBER_CREATE)))
+            .required(true);
+
+    private static final Parameter PARAM_USER_UUID = new Parameter()
+            .name("userUuid")
+            .in("path")
+            .schema(SCHEMA_STRING);
+
+    private static final Parameter PARAM_CHILD_PREFIX = new Parameter()
+            .name("childPrefix")
+            .in("path")
+            .schema(SCHEMA_STRING);
+
+    public static void generatePathsForRootResourceDefinition(Paths paths, ResourceDefinition resourceDefinition) {
+        String tag = TAG_PREFIX + resourceDefinition.getName();
+        String operationSuffix = resourceDefinition.getName();
+        Map<String, Object> extensions = Map.of("fdpResourceDefinition", resourceDefinition.getUuid());
+        // CRUD: GET, PUT, DELETE
+        paths.addPathItem(
+                "/",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix)
+                                .description("Get " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+                        .put(new Operation()
+                                .operationId("put" + operationSuffix)
+                                .description("Edit existing " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .requestBody(new RequestBody()
+                                        .description(resourceDefinition.getName() + " in RDF")
+                                        .content(CONTENT_RDF)
+                                        .required(true)
+                                )
+                                .responses(RESPONSES_RDF)
+                        )
+                        .delete(new Operation()
+                                .operationId("delete" + operationSuffix)
+                                .description("Delete existing " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_DELETE)
+                        )
+        );
+        // Spec (SHACL Shape)
+        paths.addPathItem(
+                "/spec",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Spec")
+                                .description("Get SHACL shape specification for " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // Expanded
+        paths.addPathItem(
+                "/expanded",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + StringUtils.capitalize(operationSuffix) + "Expanded")
+                                .description("Get " + resourceDefinition.getName() + " with its children")
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // Page
+        paths.addPathItem(
+                "/page/{childPrefix}",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "ChildrenPage")
+                                .description("Get a page of " + resourceDefinition.getName() + " children")
+                                .addParametersItem(PARAM_CHILD_PREFIX)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // Meta
+        paths.addPathItem(
+                "/meta",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Meta")
+                                .description("Get metadata (memberships and state) for " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_META)
+                        )
+        );
+        paths.addPathItem(
+                "/meta/state",
+                new PathItem()
+                        .extensions(extensions)
+                        .put(new Operation()
+                                .operationId("put" + operationSuffix + "MetaState")
+                                .description("Change state of " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .requestBody(BODY_META_STATE)
+                                .responses(RESPONSES_META_STATE)
+                        )
+        );
+        // Membership
+        paths.addPathItem(
+                "/members",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Members")
+                                .description("Get members of a specific " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_MEMBERS)
+                        )
+        );
+        paths.addPathItem(
+                "/members/{userUuid}",
+                new PathItem()
+                        .extensions(extensions)
+                        .put(new Operation()
+                                .operationId("put" + operationSuffix + "Member")
+                                .description("Set membership for specific user in some " + resourceDefinition.getName())
+                                .addParametersItem(PARAM_USER_UUID)
+                                .addTagsItem(tag)
+                                .requestBody(BODY_MEMBERSHIP)
+                                .responses(RESPONSES_MEMBER)
+                        )
+                        .delete(new Operation()
+                                .operationId("delete" + operationSuffix + "Member")
+                                .description("Set membership for specific user in some " + resourceDefinition.getName())
+                                .addParametersItem(PARAM_USER_UUID)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_DELETE)
+                        )
+        );
+    }
+
+    public static void generatePathsForResourceDefinition(Paths paths, ResourceDefinition resourceDefinition) {
+        String prefix = resourceDefinition.getUrlPrefix();
+        String operationSuffix = StringUtils.capitalize(prefix);
+        if (prefix.isEmpty()) {
+            generatePathsForRootResourceDefinition(paths, resourceDefinition);
+            return;
+        }
+        String parameterName = "uuid";
+        String nestedPrefix = "/" + prefix;
+        Parameter parameter = new Parameter()
+                .name(parameterName)
+                .in("path")
+                .schema(new Schema<String>().type("string"));
+        String tag = TAG_PREFIX + resourceDefinition.getName();
+        Map<String, Object> extensions = Map.of("fdpResourceDefinition", resourceDefinition.getUuid());
+        // CRUD: POST
+        paths.addPathItem(
+                "/" + prefix,
+                new PathItem()
+                        .extensions(extensions)
+                        .post(new Operation()
+                                .operationId("post" + operationSuffix)
+                                .description("Create a new " + resourceDefinition.getName())
+                                .addTagsItem(tag)
+                                .requestBody(new RequestBody()
+                                        .description(resourceDefinition.getName() + " in RDF")
+                                        .content(CONTENT_RDF)
+                                        .required(true)
+                                )
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // CRUD: GET, PUT, DELETE
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix)
+                                .description("Get " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+                        .put(new Operation()
+                                .operationId("put" + operationSuffix)
+                                .description("Edit existing " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .requestBody(new RequestBody()
+                                        .description(resourceDefinition.getName() + " in RDF")
+                                        .content(CONTENT_RDF)
+                                        .required(true)
+                                )
+                                .responses(RESPONSES_RDF)
+                        )
+                        .delete(new Operation()
+                                .operationId("delete" + operationSuffix)
+                                .description("Delete existing " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_DELETE)
+                        )
+        );
+        // Spec (SHACL Shape)
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/spec",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Spec")
+                                .description("Get SHACL shape specification for " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // Expanded
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/expanded",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Expanded")
+                                .description("Get " + resourceDefinition.getName() + " with its children")
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // Page
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/page/{childPrefix}",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "ChildrenPage")
+                                .description("Get a page of " + resourceDefinition.getName() + " children")
+                                .addParametersItem(parameter)
+                                .addParametersItem(PARAM_CHILD_PREFIX)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_RDF)
+                        )
+        );
+        // Meta
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/meta",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Meta")
+                                .description("Get metadata (memberships and state) for " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_META)
+                        )
+        );
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/meta/state",
+                new PathItem()
+                        .extensions(extensions)
+                        .put(new Operation()
+                                .operationId("put" + operationSuffix + "MetaState")
+                                .description("Change state of " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .requestBody(BODY_META_STATE)
+                                .responses(RESPONSES_META_STATE)
+                        )
+        );
+        // Membership
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/members",
+                new PathItem()
+                        .extensions(extensions)
+                        .get(new Operation()
+                                .operationId("get" + operationSuffix + "Members")
+                                .description("Get members of a specific " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_MEMBERS)
+                        )
+        );
+        paths.addPathItem(
+                nestedPrefix + "/{" + parameterName + "}/members/{userUuid}",
+                new PathItem()
+                        .extensions(extensions)
+                        .put(new Operation()
+                                .operationId("put" + operationSuffix + "Member")
+                                .description("Set membership for specific user in some " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addParametersItem(PARAM_USER_UUID)
+                                .addTagsItem(tag)
+                                .requestBody(BODY_MEMBERSHIP)
+                                .responses(RESPONSES_MEMBER)
+                        )
+                        .delete(new Operation()
+                                .operationId("delete" + operationSuffix + "Member")
+                                .description("Set membership for specific user in some " + resourceDefinition.getName())
+                                .addParametersItem(parameter)
+                                .addParametersItem(PARAM_USER_UUID)
+                                .addTagsItem(tag)
+                                .responses(RESPONSES_DELETE)
+                        )
+        );
+    }
+
+    public static Tag generateTag(ResourceDefinition resourceDefinition) {
+        return new Tag()
+                .name(TAG_PREFIX + resourceDefinition.getName())
+                .description("Metadata according to the " + resourceDefinition.getName() + " resource definition")
+                .extensions(Map.of(FDP_TAG_PRIORITY, 10));
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiService.java
@@ -1,0 +1,118 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package nl.dtls.fairdatapoint.service.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.tags.Tag;
+import lombok.extern.log4j.Log4j2;
+import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionRepository;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Log4j2
+public class OpenApiService {
+
+    @Autowired
+    private OpenAPI openAPI;
+
+    @Autowired
+    private ResourceDefinitionRepository resourceDefinitionRepository;
+
+    private Paths getGenericPaths() {
+        return (Paths) openAPI.getExtensions().get("fdpGenericPaths");
+    }
+
+    private boolean isRelatedToResourceDefinition(PathItem pathItem, ResourceDefinition rd) {
+        String rdUuid = (String) pathItem.getExtensions().getOrDefault("fdpResourceDefinition", "");
+        return rdUuid.equals(rd.getUuid());
+    }
+
+    public void updateTags(List<ResourceDefinition> resourceDefinitions) {
+        openAPI.setTags(OpenApiTagsUtils.listTags(resourceDefinitions));
+    }
+
+    public void removeGenericPaths(ResourceDefinition rd) {
+        Paths fdpGenericPaths = getGenericPaths();
+        Set<String> toRemove = fdpGenericPaths
+                .entrySet()
+                .stream()
+                .filter(item -> isRelatedToResourceDefinition(item.getValue(), rd))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+        log.info("Removing OpenAPI paths: {}", toRemove);
+        openAPI.getPaths().keySet().removeAll(toRemove);
+        fdpGenericPaths.keySet().removeAll(toRemove);
+        // Update tags
+        updateTags(resourceDefinitionRepository.findAll());
+    }
+
+    public void removeAllGenericPaths() {
+        Paths fdpGenericPaths = getGenericPaths();
+        log.info("Removing OpenAPI paths: {}", fdpGenericPaths.keySet());
+        openAPI.getPaths().keySet().removeAll(fdpGenericPaths.keySet());
+        fdpGenericPaths.clear();
+    }
+
+    public void updateGenericPaths(ResourceDefinition rd) {
+        Paths fdpGenericPaths = getGenericPaths();
+        // Cleanup
+        removeGenericPaths(rd);
+        // Generate
+        OpenApiGenerator.generatePathsForResourceDefinition(fdpGenericPaths, rd);
+        // Apply
+        log.info("Adding OpenAPI paths: {}", fdpGenericPaths.keySet());
+        openAPI.getPaths().putAll(fdpGenericPaths);
+        // Update tags
+        updateTags(resourceDefinitionRepository.findAll());
+    }
+
+    public void updateAllGenericPaths() {
+        Paths fdpGenericPaths = getGenericPaths();
+        // Cleanup
+        removeAllGenericPaths();
+        // Re-generate from Resource Definitions
+        List<ResourceDefinition> resourceDefinitions = resourceDefinitionRepository.findAll();
+        resourceDefinitions.forEach(rd -> OpenApiGenerator.generatePathsForResourceDefinition(fdpGenericPaths, rd));
+        // Apply
+        log.info("Adding OpenAPI paths: {}", fdpGenericPaths.keySet());
+        openAPI.getPaths().putAll(fdpGenericPaths);
+        updateTags(resourceDefinitions);
+    }
+
+    @PostConstruct
+    public void init() {
+        log.info("Initializing OpenAPI with generic paths");
+        updateAllGenericPaths();
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiTagsUtils.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiTagsUtils.java
@@ -1,0 +1,62 @@
+package nl.dtls.fairdatapoint.service.openapi;
+
+import io.swagger.v3.oas.models.tags.Tag;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class OpenApiTagsUtils {
+
+    private static final Comparator<String> STRING_COMPARATOR = Comparator.comparing(String::toString);
+
+    private static final Comparator<Tag> TAG_COMPARATOR = (o1, o2) -> {
+        int priority1 = (int)o1.getExtensions().getOrDefault(OpenApiGenerator.FDP_TAG_PRIORITY, 90);
+        int priority2 = (int)o2.getExtensions().getOrDefault(OpenApiGenerator.FDP_TAG_PRIORITY, 90);
+        if (priority1 < priority2) {
+            return -1;
+        } else if (priority1 > priority2) {
+            return 1;
+        }
+        return STRING_COMPARATOR.compare(o1.getName(), o2.getName());
+    };
+
+    public static final Tag METADATA_TAG = new Tag()
+            .name("Metadata")
+            .description("Common operations with all metadata")
+            .extensions(Map.of(OpenApiGenerator.FDP_TAG_PRIORITY, 0));
+
+    public static final Tag METADATA_MMODEL_TAG = new Tag()
+            .name("Metadata Model")
+            .description("Manipulation with model of metadata")
+            .extensions(Map.of(OpenApiGenerator.FDP_TAG_PRIORITY, 20));
+
+    public static final Tag METADATA_CLIENT_TAG = new Tag()
+            .name("Client")
+            .description("Endpoints for FAIR Data Point Client")
+            .extensions(Map.of(OpenApiGenerator.FDP_TAG_PRIORITY, 30));
+
+    public static final Tag METADATA_INDEX_TAG = new Tag()
+            .name("Index")
+            .description("FAIR Data Point Index endpoints")
+            .extensions(Map.of(OpenApiGenerator.FDP_TAG_PRIORITY, 40));
+
+    public static final Tag METADATA_AA_TAG = new Tag()
+            .name("Authentication and Authorization")
+            .description("Management of access to FDP (not specific type of metadata)")
+            .extensions(Map.of(OpenApiGenerator.FDP_TAG_PRIORITY, 50));
+
+    public static final Tag METADATA_USERMGMT_TAG = new Tag()
+            .name("User Management")
+            .description("Management of user accounts")
+            .extensions(Map.of(OpenApiGenerator.FDP_TAG_PRIORITY, 60));
+
+    public static final List<Tag> STATIC_TAGS = Arrays.asList(METADATA_TAG, METADATA_MMODEL_TAG, METADATA_CLIENT_TAG, METADATA_INDEX_TAG, METADATA_AA_TAG, METADATA_USERMGMT_TAG);
+
+    public static List<Tag> listTags(List<ResourceDefinition> resourceDefinitions) {
+        List<Tag> tags = resourceDefinitions.stream().map(OpenApiGenerator::generateTag).collect(Collectors.toList());
+        tags.addAll(STATIC_TAGS);
+        tags.sort(TAG_COMPARATOR);
+        return tags;
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionService.java
@@ -27,6 +27,7 @@ import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionReposit
 import nl.dtls.fairdatapoint.entity.exception.ResourceNotFoundException;
 import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import nl.dtls.fairdatapoint.service.membership.MembershipService;
+import nl.dtls.fairdatapoint.service.openapi.OpenApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -57,6 +58,9 @@ public class ResourceDefinitionService {
     @Autowired
     private MembershipService membershipService;
 
+    @Autowired
+    private OpenApiService openApiService;
+
     public List<ResourceDefinition> getAll() {
         return resourceDefinitionRepository.findAll();
     }
@@ -85,6 +89,7 @@ public class ResourceDefinitionService {
         resourceDefinitionCache.computeCache();
 
         membershipService.addToMembership(rd);
+        openApiService.updateGenericPaths(rd);
         return rd;
     }
 
@@ -101,6 +106,7 @@ public class ResourceDefinitionService {
         resourceDefinitionValidator.validate(updatedRd);
         resourceDefinitionRepository.save(updatedRd);
         resourceDefinitionCache.computeCache();
+        openApiService.updateGenericPaths(updatedRd);
         return Optional.of(updatedRd);
     }
 
@@ -132,8 +138,11 @@ public class ResourceDefinitionService {
         // 4. Delete entity from membership
         membershipService.removeFromMembership(rd);
 
-        // 4. Recompute cache
+        // 5. Recompute cache
         resourceDefinitionCache.computeCache();
+
+        // 6. Delete from OpenAPI docs
+        openApiService.removeGenericPaths(rd);
         return true;
     }
 


### PR DESCRIPTION
It generates OpenAPI docs for endpoints related to resource definitions (all on startup and then on create, update, and delete of a resource definition).

- This should be rebased after merging pagination feature as there will be also generic endpoints.
- Should we also order somehow the tags (groups of endpoints)? Those are named `Metadata: <name>` but appear at the end...

TODOs:

- [x] Generic OpenAPI for generic endpoints
- [x] Update OpenAPI when resource definition changes
- [x] Special handling of "Repository"
- [x] Order tags
- [x] Fix `*/*` content types in OpenAPI docs
