### PR TITLE
[FDP-557] Allow multiple ping endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Migrated API Docs to SpringDoc OpenAPI
+- Allow to configure multiple ping endpoints
 
 ## [1.8.0]
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/ping/PingService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/ping/PingService.java
@@ -23,15 +23,19 @@
 package nl.dtls.fairdatapoint.service.ping;
 
 
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
+@Log4j2
 @Service
 @ConditionalOnProperty(name = "ping.enabled", havingValue = "true", matchIfMissing = true)
 public class PingService {
@@ -39,16 +43,27 @@ public class PingService {
     @Value("${instance.clientUrl}")
     private String clientUrl;
 
-    @Value("${ping.endpoint:https://home.fairdatapoint.org}")
-    private String endpoint;
+    @Value("#{'${ping.endpoint:https://home.fairdatapoint.org}'.split('[, ]')}")
+    private List<String> endpoints;
 
     @Autowired
     private RestTemplate client;
 
-    @Scheduled(initialDelayString = "#{10*1000}", fixedRateString = "${ping.interval:#{7*24*60*60*1000}}")
+    @Scheduled(initialDelayString = "${ping.initDelay:#{10*1000}}", fixedRateString = "${ping.interval:#{7*24*60*60*1000}}")
     public void ping() {
         var request = Map.of("clientUrl", clientUrl);
-        client.postForEntity(endpoint, request, String.class);
+        for (String endpoint : endpoints) {
+            pingEndpoint(endpoint.trim(), request);
+        }
     }
 
+    @Async
+    void pingEndpoint(String endpoint, Map<String, String> request) {
+        try {
+            log.info("Pinging {}", endpoint);
+            client.postForEntity(endpoint, request, String.class);
+        } catch (Exception e) {
+            log.warn("Failed to ping {}: {}", endpoint, e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
This is backward compatible and allows:

```yaml
ping:
  endpoint: http://example1.com, http://example2.com
  
# OR

ping:
  endpoint: >
    http://example1.com
    http://example2.com
```

Traditional YAML lists would be more complicated as cannot be simple parsed by `@Value`.