### PR TITLE
[FDP-570] Allow to change internal shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow to change internal shapes
+
 ### Changed
 
 - Upgrade Java JDK from 15 to 16

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/shape/data/ShapeFixtures.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/shape/data/ShapeFixtures.java
@@ -199,7 +199,7 @@ public class ShapeFixtures {
                 "866d7fb8-5982-4215-9c7c-18d0ed1bd5f3",
                 "Dataset",
                 false,
-                ShapeType.INTERNAL,
+                ShapeType.CUSTOM,
                 "@prefix :         <http://fairdatapoint.org/> .\n" +
                         "@prefix dash:     <http://datashapes.org/dash#> .\n" +
                         "@prefix dcat:     <http://www.w3.org/ns/dcat#> .\n" +
@@ -253,7 +253,7 @@ public class ShapeFixtures {
                 "ebacbf83-cd4f-4113-8738-d73c0735b0ab",
                 "Distribution",
                 false,
-                ShapeType.INTERNAL,
+                ShapeType.CUSTOM,
                 "@prefix :         <http://fairdatapoint.org/> .\n" +
                         "@prefix dash:     <http://datashapes.org/dash#> .\n" +
                         "@prefix dcat:     <http://www.w3.org/ns/dcat#> .\n" +

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/production/Migration_0008_ShapesInternalChange.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/production/Migration_0008_ShapesInternalChange.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package nl.dtls.fairdatapoint.database.mongo.migration.production;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import nl.dtls.fairdatapoint.Profiles;
+import org.bson.Document;
+import org.springframework.context.annotation.Profile;
+
+@ChangeLog(order = "0008")
+@Profile(Profiles.PRODUCTION)
+public class Migration_0008_ShapesInternalChange {
+
+    @ChangeSet(order = "0008", id = "Migration_0008_ShapesInternalChange", author = "migrationBot")
+    public void run(MongoDatabase db) {
+        updateInternalShapesType(db);
+    }
+
+    private void updateInternalShapesType(MongoDatabase db) {
+        MongoCollection<Document> shapeCol = db.getCollection("shape");
+        // DATASET
+        shapeCol.updateOne(
+                Filters.eq("uuid", "866d7fb8-5982-4215-9c7c-18d0ed1bd5f3"),
+                Updates.set("type", "CUSTOM")
+        );
+        // DISTRIBUTION
+        shapeCol.updateOne(
+                Filters.eq("uuid", "ebacbf83-cd4f-4113-8738-d73c0735b0ab"),
+                Updates.set("type", "CUSTOM")
+        );
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeService.java
@@ -108,10 +108,6 @@ public class ShapeService {
             return empty();
         }
         Shape shape = oShape.get();
-        if (shape.getType() == ShapeType.INTERNAL) {
-            throw new ValidationException("You can't edit INTERNAL Shape");
-        }
-
         Shape updatedShape = shapeMapper.fromChangeDTO(reqDto, shape);
         shapeRepository.save(updatedShape);
         return of(shapeMapper.toDTO(updatedShape));
@@ -124,6 +120,9 @@ public class ShapeService {
             return false;
         }
         Shape shape = oShape.get();
+        if (shape.getType() == ShapeType.INTERNAL) {
+            throw new ValidationException("You can't delete INTERNAL Shape");
+        }
         shapeRepository.delete(shape);
         return true;
     }

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Detail_DELETE.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Detail_DELETE.java
@@ -23,6 +23,7 @@
 package nl.dtls.fairdatapoint.acceptance.shape;
 
 import nl.dtls.fairdatapoint.WebIntegrationTest;
+import nl.dtls.fairdatapoint.api.dto.error.ErrorDTO;
 import nl.dtls.fairdatapoint.database.mongo.migration.development.shape.data.ShapeFixtures;
 import nl.dtls.fairdatapoint.entity.shape.Shape;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +58,7 @@ public class Detail_DELETE extends WebIntegrationTest {
     @DisplayName("HTTP 204")
     public void res204() {
         // GIVEN:
-        Shape shape = shapeFixtures.repositoryShape();
+        Shape shape = shapeFixtures.datasetShape();
         RequestEntity<Void> request = RequestEntity
                 .delete(url(shape.getUuid()))
                 .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
@@ -73,16 +74,35 @@ public class Detail_DELETE extends WebIntegrationTest {
     }
 
     @Test
+    @DisplayName("HTTP 400: Delete INTERNAL shape")
+    public void res400() {
+        // GIVEN:
+        Shape shape = shapeFixtures.repositoryShape();
+        RequestEntity<Void> request = RequestEntity
+                .delete(url(shape.getUuid()))
+                .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                .build();
+        ParameterizedTypeReference<ErrorDTO> responseType = new ParameterizedTypeReference<>() {
+        };
+
+        // WHEN:
+        ResponseEntity<ErrorDTO> result = client.exchange(request, responseType);
+
+        // THEN:
+        assertThat(result.getStatusCode(), is(equalTo(HttpStatus.BAD_REQUEST)));
+    }
+
+    @Test
     @DisplayName("HTTP 403: User is not authenticated")
     public void res403_notAuthenticated() {
-        Shape shape = shapeFixtures.repositoryShape();
+        Shape shape = shapeFixtures.datasetShape();
         createUserForbiddenTestDelete(client, url(shape.getUuid()));
     }
 
     @Test
     @DisplayName("HTTP 403: User is not an admin")
     public void res403_shape() {
-        Shape shape = shapeFixtures.repositoryShape();
+        Shape shape = shapeFixtures.datasetShape();
         createUserForbiddenTestDelete(client, url(shape.getUuid()));
     }
 

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Detail_PUT.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Detail_PUT.java
@@ -146,8 +146,8 @@ public class Detail_PUT extends WebIntegrationTest {
     }
 
     @Test
-    @DisplayName("HTTP 400: Edit INTERNAL shape")
-    public void res400() {
+    @DisplayName("HTTP 200: Edit INTERNAL shape")
+    public void res200_internal() {
         // GIVEN:
         Shape shape = shapeFixtures.repositoryShape();
         ShapeChangeDTO reqDto = reqDto(shape);
@@ -156,14 +156,15 @@ public class Detail_PUT extends WebIntegrationTest {
                 .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
                 .accept(MediaType.APPLICATION_JSON)
                 .body(reqDto);
-        ParameterizedTypeReference<ErrorDTO> responseType = new ParameterizedTypeReference<>() {
+        ParameterizedTypeReference<ShapeDTO> responseType = new ParameterizedTypeReference<>() {
         };
 
         // WHEN:
-        ResponseEntity<ErrorDTO> result = client.exchange(request, responseType);
+        ResponseEntity<ShapeDTO> result = client.exchange(request, responseType);
 
         // THEN:
-        assertThat(result.getStatusCode(), is(equalTo(HttpStatus.BAD_REQUEST)));
+        assertThat(result.getStatusCode(), is(equalTo(HttpStatus.OK)));
+        Common.compare(reqDto, result.getBody());
     }
 
     @Test


### PR DESCRIPTION
Now it is possible to change internal shapes (but not delete them). Both dataset and distribution are no longer marked as internal; therefore, can be even deleted.