### PR TITLE
[FDP-561] Allow reset to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Allow to change internal shapes
+- Reset to "factory defaults" (users, resource definitions, metadata)
 
 ### Changed
 

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/reset/ResetController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/reset/ResetController.java
@@ -20,30 +20,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package nl.dtls.fairdatapoint.entity.resource;
+package nl.dtls.fairdatapoint.api.controller.reset;
 
-import lombok.*;
-import nl.dtls.fairdatapoint.api.validator.ValidIri;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import nl.dtls.fairdatapoint.api.dto.reset.ResetDTO;
+import nl.dtls.fairdatapoint.service.reset.ResetService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@Setter
-@EqualsAndHashCode
-@Builder(toBuilder = true)
-public class ResourceDefinitionChild {
+@Tag(name = "Client")
+@RestController
+public class ResetController {
 
-    @NotBlank
-    protected String resourceDefinitionUuid;
+    @Autowired
+    private ResetService resetService;
 
-    @NotBlank
-    @ValidIri
-    protected String relationUri;
-
-    @Valid
-    protected ResourceDefinitionChildListView listView;
+    @PostMapping("/reset")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> postResetFactoryDefaults(@RequestBody @Valid ResetDTO reqDto) throws Exception {
+        resetService.resetToFactoryDefaults(reqDto);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/reset/ResetDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/reset/ResetDTO.java
@@ -1,0 +1,19 @@
+package nl.dtls.fairdatapoint.api.dto.reset;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResetDTO {
+
+    private boolean user;
+
+    private boolean metadata;
+
+    private boolean resourceDefinition;
+}

--- a/src/main/java/nl/dtls/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0001_Init.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0001_Init.java
@@ -24,6 +24,7 @@ package nl.dtls.fairdatapoint.database.rdf.migration.production;
 
 import com.mongodb.client.MongoCollection;
 import lombok.extern.slf4j.Slf4j;
+import nl.dtls.fairdatapoint.service.reset.FactoryDefaults;
 import nl.dtls.fairdatapoint.vocabulary.DATACITE;
 import nl.dtls.fairdatapoint.vocabulary.FDP;
 import nl.dtls.fairdatapoint.vocabulary.R3D;
@@ -95,50 +96,13 @@ public class Rdf_Migration_0001_Init implements RdfProductionMigration {
 
     private void createRepositoryInTripleStore() {
         try (RepositoryConnection conn = repository.getConnection()) {
-            List<Statement> s = new ArrayList<>();
-            add(s, RDF.TYPE, R3D.REPOSITORY);
-            add(s, RDF.TYPE, i("http://www.w3.org/ns/dcat#Resource"));
-            add(s, DCTERMS.TITLE, l("My FAIR Data Point"));
-            add(s, RDFS.LABEL, l("My FAIR Data Point"));
-            add(s, DCTERMS.HAS_VERSION, l(1.0f));
-            add(s, FDP.METADATAISSUED, l(OffsetDateTime.now()));
-            add(s, FDP.METADATAMODIFIED, l(OffsetDateTime.now()));
-            add(s, DCTERMS.LICENSE, license);
-            add(s, DCTERMS.DESCRIPTION, l("Duis pellentesque, nunc a fringilla varius, magna dui porta quam, nec " +
-                    "ultricies augue turpis sed velit. Donec id consectetur ligula. Suspendisse pharetra egestas " +
-                    "massa, vel varius leo viverra at. Donec scelerisque id ipsum id semper. Maecenas facilisis augue" +
-                    " vel justo molestie aliquet. Maecenas sed mattis lacus, sed viverra risus. Donec iaculis quis " +
-                    "lacus vitae scelerisque. Nullam fermentum lectus nisi, id vulputate nisi congue nec. Morbi " +
-                    "fermentum justo at justo bibendum, at tempus ipsum tempor. Donec facilisis nibh sed lectus " +
-                    "blandit venenatis. Cras ullamcorper, justo vitae feugiat commodo, orci metus suscipit purus, " +
-                    "quis sagittis turpis ante eget ex. Pellentesque malesuada a metus eu pulvinar. Morbi rutrum " +
-                    "euismod eros at varius. Duis finibus dapibus ex, a hendrerit mauris efficitur at."));
-            add(s, DCTERMS.CONFORMS_TO, i("https://www.purl.org/fairtools/fdp/schema/0.1/fdpMetadata"));
-            add(s, DCTERMS.LANGUAGE, language);
-            // Identifier
-            IRI identifierIri = i(persistentUrl + "#identifier");
-            add(s, FDP.METADATAIDENTIFIER, identifierIri);
-            add(s, identifierIri, RDF.TYPE, DATACITE.IDENTIFIER);
-            add(s, identifierIri, DCTERMS.IDENTIFIER, l(persistentUrl));
-            // Repository Identifier
-            add(s, R3D.REPOSITORYIDENTIFIER, identifierIri);
-            // Access Rights
-            IRI arIri = i(persistentUrl + "#accessRights");
-            add(s, DCTERMS.ACCESS_RIGHTS, arIri);
-            add(s, arIri, RDF.TYPE, DCTERMS.RIGHTS_STATEMENT);
-            add(s, arIri, DCTERMS.DESCRIPTION, l(accessRightsDescription));
-            // Publisher
-            IRI publisherIri = i(persistentUrl + "#publisher");
-            add(s, DCTERMS.PUBLISHER, publisherIri);
-            add(s, publisherIri, RDF.TYPE, FOAF.AGENT);
-            add(s, publisherIri, FOAF.NAME, l("Default Publisher"));
-            // Metrics
-            metadataMetrics.forEach((metric, metricValue) -> {
-                IRI metUri = i(format("%s/metrics/%s", persistentUrl, DigestUtils.md5Hex(metric)));
-                add(s, Sio.REFERS_TO, metUri);
-                add(s, metUri, Sio.IS_ABOUT, i(metric));
-                add(s, metUri, Sio.REFERS_TO, i(metricValue));
-            });
+            List<Statement> s = FactoryDefaults.repositoryStatements(
+                    persistentUrl,
+                    metadataMetrics,
+                    license,
+                    language,
+                    accessRightsDescription
+            );
             conn.add(s);
         } catch (RepositoryException e) {
             log.error(e.getMessage(), e);
@@ -151,53 +115,7 @@ public class Rdf_Migration_0001_Init implements RdfProductionMigration {
     }
 
     private Document repositoryPermission() {
-        String albertUuid = "7e64818d-6276-46fb-8bb1-732e6e09f7e9";
-        BasicBSONObject owner = new BasicBSONObject().append("name", albertUuid).append("isPrincipal", true);
-        Document acl = new Document();
-        acl.append("className", "nl.dtls.fairdatapoint.entity.metadata.FDPMetadata");
-        acl.append("instanceId", persistentUrl);
-        acl.append("owner", owner);
-        acl.append("inheritPermissions", true);
-        BasicBSONList permissions = new BasicBSONList();
-        permissions.add(
-                new Document()
-                        .append("sid", owner)
-                        .append("permission", 2)
-                        .append("granting", true)
-                        .append("auditFailure", false)
-                        .append("auditSuccess", false));
-        permissions.add(
-                new Document()
-                        .append("sid", owner)
-                        .append("permission", 4)
-                        .append("granting", true)
-                        .append("auditFailure", false)
-                        .append("auditSuccess", false));
-        permissions.add(
-                new Document()
-                        .append("sid", owner)
-                        .append("permission", 8)
-                        .append("granting", true)
-                        .append("auditFailure", false)
-                        .append("auditSuccess", false));
-        permissions.add(
-                new Document()
-                        .append("sid", owner)
-                        .append("permission", 16)
-                        .append("granting", true)
-                        .append("auditFailure", false)
-                        .append("auditSuccess", false));
-        acl.append("permissions", permissions);
-        acl.append("_class", "org.springframework.security.acls.domain.MongoAcl");
-        return acl;
-    }
-
-    private void add(List<Statement> statements, IRI predicate, org.eclipse.rdf4j.model.Value object) {
-        statements.add(s(i(persistentUrl), predicate, object, i(persistentUrl)));
-    }
-
-    private void add(List<Statement> statements, IRI subject, IRI predicate, org.eclipse.rdf4j.model.Value object) {
-        statements.add(s(subject, predicate, object, i(persistentUrl)));
+        return FactoryDefaults.aclRepository(persistentUrl);
     }
 
 }

--- a/src/main/java/nl/dtls/fairdatapoint/entity/resource/ResourceDefinition.java
+++ b/src/main/java/nl/dtls/fairdatapoint/entity/resource/ResourceDefinition.java
@@ -37,6 +37,7 @@ import java.util.List;
 @Getter
 @Setter
 @EqualsAndHashCode
+@Builder(toBuilder = true)
 public class ResourceDefinition {
 
     @Id

--- a/src/main/java/nl/dtls/fairdatapoint/entity/resource/ResourceDefinitionChildListView.java
+++ b/src/main/java/nl/dtls/fairdatapoint/entity/resource/ResourceDefinitionChildListView.java
@@ -34,6 +34,7 @@ import java.util.List;
 @Getter
 @Setter
 @EqualsAndHashCode
+@Builder(toBuilder = true)
 public class ResourceDefinitionChildListView {
 
     @NotBlank

--- a/src/main/java/nl/dtls/fairdatapoint/service/reset/FactoryDefaults.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/reset/FactoryDefaults.java
@@ -1,0 +1,358 @@
+package nl.dtls.fairdatapoint.service.reset;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import nl.dtls.fairdatapoint.entity.membership.Membership;
+import nl.dtls.fairdatapoint.entity.membership.MembershipPermission;
+import nl.dtls.fairdatapoint.entity.metadata.Metadata;
+import nl.dtls.fairdatapoint.entity.metadata.MetadataState;
+import nl.dtls.fairdatapoint.entity.resource.*;
+import nl.dtls.fairdatapoint.entity.shape.Shape;
+import nl.dtls.fairdatapoint.entity.shape.ShapeType;
+import nl.dtls.fairdatapoint.entity.user.User;
+import nl.dtls.fairdatapoint.entity.user.UserRole;
+import nl.dtls.fairdatapoint.vocabulary.DATACITE;
+import nl.dtls.fairdatapoint.vocabulary.FDP;
+import nl.dtls.fairdatapoint.vocabulary.R3D;
+import nl.dtls.fairdatapoint.vocabulary.Sio;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.bson.BasicBSONObject;
+import org.bson.Document;
+import org.bson.types.BasicBSONList;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static nl.dtls.fairdatapoint.util.ValueFactoryHelper.*;
+
+public class FactoryDefaults {
+
+    //== USERS
+    // Changes: Migration_0001_Init
+    public static final User USER_ALBERT = User.builder()
+            .uuid("7e64818d-6276-46fb-8bb1-732e6e09f7e9")
+            .firstName("Albert")
+            .lastName("Einstein")
+            .email("albert.einstein@example.com")
+            .passwordHash("$2a$10$t2foZfp7cZFQo2u/33ZqTu2WNitBqYd2EY2tQO0/rBUdf8QfsAxyW")
+            .role(UserRole.ADMIN)
+            .build();
+
+    public static final User USER_NIKOLA = User.builder()
+            .uuid("b5b92c69-5ed9-4054-954d-0121c29b6800")
+            .firstName("Nikola")
+            .lastName("Tesla")
+            .email("nikola.tesla@example.com")
+            .passwordHash("$2a$10$t2foZfp7cZFQo2u/33ZqTu2WNitBqYd2EY2tQO0/rBUdf8QfsAxyW")
+            .role(UserRole.USER)
+            .build();
+
+    //== MEMBERSHIPS
+    // Changes: Migration_0001_Init, Migration_0004_ResourceDefinition
+    public static final Membership MEMBERSHIP_OWNER = Membership.builder()
+            .uuid("49f2bcfd-ef0a-4a3a-a1a3-0fc72a6892a8")
+            .name("Owner")
+            .permissions(List.of(
+                    new MembershipPermission(2, 'W'),
+                    new MembershipPermission(4, 'C'),
+                    new MembershipPermission(8, 'D'),
+                    new MembershipPermission(16, 'A')
+            ))
+            .allowedEntities(List.of(
+                    "a0949e72-4466-4d53-8900-9436d1049a4b",
+                    "2f08228e-1789-40f8-84cd-28e3288c3604",
+                    "02c649de-c579-43bb-b470-306abdc808c7"
+            ))
+            .build();
+
+    public static final Membership MEMBERSHIP_DATA_PROVIDER = Membership.builder()
+            .uuid("87a2d984-7db2-43f6-805c-6b0040afead5")
+            .name("Data Provider")
+            .permissions(List.of(
+                    new MembershipPermission(4, 'C')
+            ))
+            .allowedEntities(List.of(
+                    "a0949e72-4466-4d53-8900-9436d1049a4b"
+            ))
+            .build();
+
+    //== RESOURCE DEFINITIONS
+    // Changes: Migration_0002_CustomMetamodel, Migration_0004_ResourceDefinition
+    public static final ResourceDefinition RESOURCE_DEFINITION_REPOSITORY = ResourceDefinition.builder()
+            .uuid("77aaad6a-0136-4c6e-88b9-07ffccd0ee4c")
+            .name("Repository")
+            .urlPrefix("")
+            .targetClassUris(List.of(
+                    "http://www.w3.org/ns/dcat#Resource",
+                    "http://www.re3data.org/schema/3-0#Repository"
+            ))
+            .children(List.of(
+                    ResourceDefinitionChild.builder()
+                            .resourceDefinitionUuid("a0949e72-4466-4d53-8900-9436d1049a4b")
+                            .relationUri("http://www.re3data.org/schema/3-0#dataCatalog")
+                            .listView(
+                                    ResourceDefinitionChildListView.builder()
+                                            .title("Catalogs")
+                                            .tagsUri("http://www.w3.org/ns/dcat#themeTaxonomy")
+                                            .metadata(List.of())
+                                            .build()
+                            )
+                            .build()
+            ))
+            .externalLinks(List.of())
+            .build();
+
+    public static final ResourceDefinition RESOURCE_DEFINITION_CATALOG = ResourceDefinition.builder()
+            .uuid("a0949e72-4466-4d53-8900-9436d1049a4b")
+            .name("Catalog")
+            .urlPrefix("catalog")
+            .targetClassUris(List.of(
+                    "http://www.w3.org/ns/dcat#Resource",
+                    "http://www.w3.org/ns/dcat#Catalog"
+            ))
+            .children(List.of(
+                    ResourceDefinitionChild.builder()
+                            .resourceDefinitionUuid("2f08228e-1789-40f8-84cd-28e3288c3604")
+                            .relationUri("http://www.w3.org/ns/dcat#dataset")
+                            .listView(
+                                    ResourceDefinitionChildListView.builder()
+                                            .title("Datasets")
+                                            .tagsUri("http://www.w3.org/ns/dcat#theme")
+                                            .metadata(List.of())
+                                            .build()
+                            )
+                            .build()
+            ))
+            .externalLinks(List.of())
+            .build();
+
+    public static final ResourceDefinition RESOURCE_DEFINITION_DATASET = ResourceDefinition.builder()
+            .uuid("2f08228e-1789-40f8-84cd-28e3288c3604")
+            .name("Dataset")
+            .urlPrefix("dataset")
+            .targetClassUris(List.of(
+                    "http://www.w3.org/ns/dcat#Resource",
+                    "http://www.w3.org/ns/dcat#Dataset"
+            ))
+            .children(List.of(
+                    ResourceDefinitionChild.builder()
+                            .resourceDefinitionUuid("02c649de-c579-43bb-b470-306abdc808c7")
+                            .relationUri("http://www.w3.org/ns/dcat#distribution")
+                            .listView(
+                                    ResourceDefinitionChildListView.builder()
+                                            .title("Distributions")
+                                            .tagsUri(null)
+                                            .metadata(List.of(
+                                                    new ResourceDefinitionChildListViewMetadata(
+                                                            "Media Type",
+                                                            "http://www.w3.org/ns/dcat#mediaType"
+                                                    )
+                                            ))
+                                            .build()
+                            )
+                            .build()
+            ))
+            .externalLinks(List.of())
+            .build();
+
+    public static final ResourceDefinition RESOURCE_DEFINITION_DISTRIBUTION = ResourceDefinition.builder()
+            .uuid("02c649de-c579-43bb-b470-306abdc808c7")
+            .name("Distribution")
+            .urlPrefix("distribution")
+            .targetClassUris(List.of(
+                    "http://www.w3.org/ns/dcat#Resource",
+                    "http://www.w3.org/ns/dcat#Distribution"
+            ))
+            .children(List.of())
+            .externalLinks(List.of(
+                    new ResourceDefinitionLink(
+                            "Access online",
+                            "http://www.w3.org/ns/dcat#accessURL"
+                    ),
+                    new ResourceDefinitionLink(
+                            "Download",
+                            "http://www.w3.org/ns/dcat#downloadURL"
+                    )
+            ))
+            .build();
+
+    //== SHAPES
+    //== Changes: Migration_0003_ShapeDefinition, Migration_0005_UpdateShapeDefinition, Migration_0006_ShapesSharing
+    public static Shape shapeResource() throws Exception {
+        return Shape.builder()
+                .uuid("6a668323-3936-4b53-8380-a4fd2ed082ee")
+                .name("Resource")
+                .type(ShapeType.INTERNAL)
+                .published(false)
+                .definition(loadShape("shape-resource.ttl"))
+                .build();
+    }
+
+    public static Shape shapeRepository() throws Exception {
+        return Shape.builder()
+                .uuid("a92958ab-a414-47e6-8e17-68ba96ba3a2b")
+                .name("Repository")
+                .type(ShapeType.INTERNAL)
+                .published(false)
+                .definition(loadShape("shape-repository.ttl"))
+                .build();
+    }
+
+    public static Shape shapeCatalog() throws Exception {
+        return Shape.builder()
+                .uuid("2aa7ba63-d27a-4c0e-bfa6-3a4e250f4660")
+                .name("Catalog")
+                .type(ShapeType.INTERNAL)
+                .published(false)
+                .definition(loadShape("shape-catalog.ttl"))
+                .build();
+    }
+
+    public static Shape shapeDataset() throws Exception {
+        return Shape.builder()
+                .uuid("866d7fb8-5982-4215-9c7c-18d0ed1bd5f3")
+                .name("Dataset")
+                .type(ShapeType.CUSTOM)
+                .published(false)
+                .definition(loadShape("shape-dataset.ttl"))
+                .build();
+    }
+
+    public static Shape shapeDistribution() throws Exception {
+        return Shape.builder()
+                .uuid("ebacbf83-cd4f-4113-8738-d73c0735b0ab")
+                .name("Distribution")
+                .type(ShapeType.CUSTOM)
+                .published(false)
+                .definition(loadShape("shape-distribution.ttl"))
+                .build();
+    }
+
+    // Repository ACL
+    public static Document aclRepository(String persistentUrl) {
+        BasicBSONObject owner = new BasicBSONObject()
+                .append("name", USER_ALBERT.getUuid())
+                .append("isPrincipal", true);
+        Document acl = new Document();
+        acl.append("className", "nl.dtls.fairdatapoint.entity.metadata.FDPMetadata");
+        acl.append("instanceId", persistentUrl);
+        acl.append("owner", owner);
+        acl.append("inheritPermissions", true);
+        BasicBSONList permissions = new BasicBSONList();
+        permissions.add(
+                new Document()
+                        .append("sid", owner)
+                        .append("permission", 2)
+                        .append("granting", true)
+                        .append("auditFailure", false)
+                        .append("auditSuccess", false));
+        permissions.add(
+                new Document()
+                        .append("sid", owner)
+                        .append("permission", 4)
+                        .append("granting", true)
+                        .append("auditFailure", false)
+                        .append("auditSuccess", false));
+        permissions.add(
+                new Document()
+                        .append("sid", owner)
+                        .append("permission", 8)
+                        .append("granting", true)
+                        .append("auditFailure", false)
+                        .append("auditSuccess", false));
+        permissions.add(
+                new Document()
+                        .append("sid", owner)
+                        .append("permission", 16)
+                        .append("granting", true)
+                        .append("auditFailure", false)
+                        .append("auditSuccess", false));
+        acl.append("permissions", permissions);
+        acl.append("_class", "org.springframework.security.acls.domain.MongoAcl");
+        return acl;
+    }
+
+    // Repository RDF statements
+    private static final String LIPSUM_TEXT = "Duis pellentesque, nunc a fringilla varius, magna dui porta quam, nec " +
+            "ultricies augue turpis sed velit. Donec id consectetur ligula. Suspendisse pharetra egestas " +
+            "massa, vel varius leo viverra at. Donec scelerisque id ipsum id semper. Maecenas facilisis augue" +
+            " vel justo molestie aliquet. Maecenas sed mattis lacus, sed viverra risus. Donec iaculis quis " +
+            "lacus vitae scelerisque. Nullam fermentum lectus nisi, id vulputate nisi congue nec. Morbi " +
+            "fermentum justo at justo bibendum, at tempus ipsum tempor. Donec facilisis nibh sed lectus " +
+            "blandit venenatis. Cras ullamcorper, justo vitae feugiat commodo, orci metus suscipit purus, " +
+            "quis sagittis turpis ante eget ex. Pellentesque malesuada a metus eu pulvinar. Morbi rutrum " +
+            "euismod eros at varius. Duis finibus dapibus ex, a hendrerit mauris efficitur at.";
+
+    public static List<Statement> repositoryStatements(String persistentUrl, Map<String, String> metadataMetrics, IRI license, IRI language, String accessRightsDescription) {
+        List<Statement> s = new ArrayList<>();
+        IRI baseUrl = i(persistentUrl);
+        FactoryDefaults.add(s, RDF.TYPE, R3D.REPOSITORY, baseUrl);
+        FactoryDefaults.add(s, RDF.TYPE, i("http://www.w3.org/ns/dcat#Resource"), baseUrl);
+        FactoryDefaults.add(s, DCTERMS.TITLE, l("My FAIR Data Point"), baseUrl);
+        FactoryDefaults.add(s, RDFS.LABEL, l("My FAIR Data Point"), baseUrl);
+        FactoryDefaults.add(s, DCTERMS.HAS_VERSION, l(1.0f), baseUrl);
+        FactoryDefaults.add(s, FDP.METADATAISSUED, l(OffsetDateTime.now()), baseUrl);
+        FactoryDefaults.add(s, FDP.METADATAMODIFIED, l(OffsetDateTime.now()), baseUrl);
+        FactoryDefaults.add(s, DCTERMS.LICENSE, license, baseUrl);
+        FactoryDefaults.add(s, DCTERMS.DESCRIPTION, l(LIPSUM_TEXT), baseUrl);
+        FactoryDefaults.add(s, DCTERMS.CONFORMS_TO, i("https://www.purl.org/fairtools/fdp/schema/0.1/fdpMetadata"), baseUrl);
+        FactoryDefaults.add(s, DCTERMS.LANGUAGE, language, baseUrl);
+        // Identifier
+        IRI identifierIri = i(persistentUrl + "#identifier");
+        FactoryDefaults.add(s, FDP.METADATAIDENTIFIER, identifierIri, baseUrl);
+        FactoryDefaults.add(s, identifierIri, RDF.TYPE, DATACITE.IDENTIFIER, baseUrl);
+        FactoryDefaults.add(s, identifierIri, DCTERMS.IDENTIFIER, l(persistentUrl), baseUrl);
+        // Repository Identifier
+        FactoryDefaults.add(s, R3D.REPOSITORYIDENTIFIER, identifierIri, baseUrl);
+        // Access Rights
+        IRI arIri = i(persistentUrl + "#accessRights");
+        FactoryDefaults.add(s, DCTERMS.ACCESS_RIGHTS, arIri, baseUrl);
+        FactoryDefaults.add(s, arIri, RDF.TYPE, DCTERMS.RIGHTS_STATEMENT, baseUrl);
+        FactoryDefaults.add(s, arIri, DCTERMS.DESCRIPTION, l(accessRightsDescription), baseUrl);
+        // Publisher
+        IRI publisherIri = i(persistentUrl + "#publisher");
+        FactoryDefaults.add(s, DCTERMS.PUBLISHER, publisherIri, baseUrl);
+        FactoryDefaults.add(s, publisherIri, RDF.TYPE, FOAF.AGENT, baseUrl);
+        FactoryDefaults.add(s, publisherIri, FOAF.NAME, l("Default Publisher"), baseUrl);
+        // Metrics
+        metadataMetrics.forEach((metric, metricValue) -> {
+            IRI metUri = i(format("%s/metrics/%s", persistentUrl, DigestUtils.md5Hex(metric)));
+            FactoryDefaults.add(s, Sio.REFERS_TO, metUri, baseUrl);
+            FactoryDefaults.add(s, metUri, Sio.IS_ABOUT, i(metric), baseUrl);
+            FactoryDefaults.add(s, metUri, Sio.REFERS_TO, i(metricValue), baseUrl);
+        });
+        return s;
+    }
+
+    public static Metadata metadataRepository(String persistentUrl) {
+        return Metadata.builder()
+                .uri(persistentUrl)
+                .state(MetadataState.PUBLISHED)
+                .build();
+    }
+
+    private static String loadShape(String name) throws Exception {
+        return Resources.toString(
+                FactoryDefaults.class.getResource(name),
+                Charsets.UTF_8
+        );
+    }
+
+    private static void add(List<Statement> statements, IRI predicate, org.eclipse.rdf4j.model.Value object, IRI base) {
+        statements.add(s(base, predicate, object, base));
+    }
+
+    private static void add(List<Statement> statements, IRI subject, IRI predicate, org.eclipse.rdf4j.model.Value object, IRI base) {
+        statements.add(s(subject, predicate, object, base));
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/reset/ResetService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/reset/ResetService.java
@@ -1,0 +1,212 @@
+package nl.dtls.fairdatapoint.service.reset;
+
+import com.mongodb.client.MongoCollection;
+import lombok.extern.slf4j.Slf4j;
+import nl.dtls.fairdatapoint.api.dto.reset.ResetDTO;
+import nl.dtls.fairdatapoint.database.mongo.repository.*;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import nl.dtls.fairdatapoint.service.metadata.exception.MetadataServiceException;
+import nl.dtls.fairdatapoint.service.metadata.generic.GenericMetadataService;
+import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionCache;
+import nl.dtls.fairdatapoint.vocabulary.DATACITE;
+import nl.dtls.fairdatapoint.vocabulary.FDP;
+import nl.dtls.fairdatapoint.vocabulary.R3D;
+import nl.dtls.fairdatapoint.vocabulary.Sio;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.bson.Document;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.acls.dao.AclRepository;
+import org.springframework.security.acls.model.AclCache;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static nl.dtls.fairdatapoint.util.ValueFactoryHelper.i;
+import static nl.dtls.fairdatapoint.util.ValueFactoryHelper.l;
+
+@Slf4j
+@Service
+public class ResetService {
+
+    @Autowired
+    @Qualifier("persistentUrl")
+    private String persistentUrl;
+
+    @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
+    private String accessRightsDescription;
+
+    @Autowired
+    private IRI license;
+
+    @Autowired
+    private IRI language;
+
+    @Autowired
+    @Qualifier("metadataMetrics")
+    private Map<String, String> metadataMetrics;
+
+    @Autowired
+    protected Repository repository;
+
+    @Autowired
+    private ApiKeyRepository apiKeyRepository;
+
+    @Autowired
+    private MembershipRepository membershipRepository;
+
+    @Autowired
+    private AclRepository aclRepository;
+
+    @Autowired
+    private AclCache aclCache;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShapeRepository shapeRepository;
+
+    @Autowired
+    private ResourceDefinitionRepository resourceDefinitionRepository;
+
+    @Autowired
+    private ResourceDefinitionCache resourceDefinitionCache;
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+
+    @Autowired
+    private GenericMetadataService genericMetadataService;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @PreAuthorize("hasRole('ADMIN')")
+    public void resetToFactoryDefaults(ResetDTO reqDto) throws Exception {
+        log.info("Resetting to factory defaults");
+        if (reqDto.isUser() || reqDto.isMetadata()) {
+            clearMemberships();
+            restoreDefaultMemberships();
+        }
+        if (reqDto.isUser()) {
+            clearApiKeys();
+            clearUsers();
+            restoreDefaultUsers();
+        }
+        if (reqDto.isMetadata()) {
+            clearMetadata();
+            restoreDefaultMetadata();
+        }
+        if (reqDto.isResourceDefinition()) {
+            clearShapes();
+            clearResourceDefinitions();
+            restoreDefaultShapes();
+            restoreDefaultResourceDefinitions();
+        }
+    }
+
+    private void clearApiKeys() {
+        log.debug("Clearing API keys");
+        apiKeyRepository.deleteAll();
+    }
+
+    private void clearMemberships() {
+        log.debug("Clearing memberships");
+        membershipRepository.deleteAll();
+        log.debug("Clearing ACL cache");
+        aclRepository.deleteAll();
+        aclCache.clearCache();
+    }
+
+    private void clearUsers() {
+        log.debug("Clearing users");
+        userRepository.deleteAll();
+    }
+
+    private void clearShapes() {
+        log.debug("Clearing SHACL shapes");
+        shapeRepository.deleteAll();
+    }
+
+    private void clearResourceDefinitions() {
+        log.debug("Clearing resource definitions");
+        resourceDefinitionRepository.deleteAll();
+        resourceDefinitionCache.computeCache();
+    }
+
+    private void clearMetadata() throws MetadataServiceException {
+        log.debug("Clearing metadata");
+        Optional<ResourceDefinition> rd = resourceDefinitionRepository.findByUrlPrefix("");
+        if (rd.isPresent()) {
+            genericMetadataService.delete(i(persistentUrl), rd.get());
+            metadataRepository.deleteAll();
+        }
+    }
+
+    private void restoreDefaultUsers() {
+        log.debug("Creating default users");
+        userRepository.save(FactoryDefaults.USER_ALBERT);
+        userRepository.save(FactoryDefaults.USER_NIKOLA);
+    }
+
+    private void restoreDefaultMemberships() {
+        log.debug("Creating default users");
+        membershipRepository.save(FactoryDefaults.MEMBERSHIP_OWNER);
+        membershipRepository.save(FactoryDefaults.MEMBERSHIP_DATA_PROVIDER);
+
+        MongoCollection<Document> aclCol = mongoTemplate.getCollection("ACL");
+        aclCol.insertOne(FactoryDefaults.aclRepository(persistentUrl));
+    }
+
+    private void restoreDefaultMetadata() {
+        log.debug("Creating default metadata");
+        try (RepositoryConnection conn = repository.getConnection()) {
+            List<Statement> s = FactoryDefaults.repositoryStatements(
+                    persistentUrl,
+                    metadataMetrics,
+                    license,
+                    language,
+                    accessRightsDescription
+            );
+            conn.add(s);
+            metadataRepository.save(FactoryDefaults.metadataRepository(persistentUrl));
+        } catch (RepositoryException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    private void restoreDefaultShapes() throws Exception {
+        log.debug("Creating default shapes");
+        shapeRepository.save(FactoryDefaults.shapeResource());
+        shapeRepository.save(FactoryDefaults.shapeRepository());
+        shapeRepository.save(FactoryDefaults.shapeCatalog());
+        shapeRepository.save(FactoryDefaults.shapeDataset());
+        shapeRepository.save(FactoryDefaults.shapeDistribution());
+    }
+
+    private void restoreDefaultResourceDefinitions() {
+        log.debug("Creating default resource definitions");
+        resourceDefinitionRepository.save(FactoryDefaults.RESOURCE_DEFINITION_REPOSITORY);
+        resourceDefinitionRepository.save(FactoryDefaults.RESOURCE_DEFINITION_CATALOG);
+        resourceDefinitionRepository.save(FactoryDefaults.RESOURCE_DEFINITION_DATASET);
+        resourceDefinitionRepository.save(FactoryDefaults.RESOURCE_DEFINITION_DISTRIBUTION);
+    }
+}

--- a/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-catalog.ttl
+++ b/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-catalog.ttl
@@ -1,0 +1,30 @@
+@prefix :         <http://fairdatapoint.org/> .
+@prefix dash:     <http://datashapes.org/dash#> .
+@prefix dcat:     <http://www.w3.org/ns/dcat#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix foaf:     <http://xmlns.com/foaf/0.1/> .
+@prefix sh:       <http://www.w3.org/ns/shacl#> .
+
+:CatalogShape a sh:NodeShape ;
+  sh:targetClass dcat:Catalog ;
+  sh:property [
+    sh:path dct:issued ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dct:modified ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path foaf:homePage ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path dcat:themeTaxonomy ;
+    sh:nodeKind sh:IRI ;
+    dash:viewer dash:LabelViewer ;
+  ] .

--- a/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-dataset.ttl
+++ b/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-dataset.ttl
@@ -1,0 +1,44 @@
+@prefix :         <http://fairdatapoint.org/> .
+@prefix dash:     <http://datashapes.org/dash#> .
+@prefix dcat:     <http://www.w3.org/ns/dcat#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix sh:       <http://www.w3.org/ns/shacl#> .
+
+:DatasetShape a sh:NodeShape ;
+  sh:targetClass dcat:Dataset ;
+  sh:property [
+    sh:path dct:issued ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:editor dash:DatePickerEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dct:modified ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:editor dash:DatePickerEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ],  [
+    sh:path dcat:theme ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path dcat:contactPoint ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path dcat:keyword ;
+    sh:nodeKind sh:Literal ;
+    dash:editor dash:TextFieldEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dcat:landingPage ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ] .

--- a/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-distribution.ttl
+++ b/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-distribution.ttl
@@ -1,0 +1,50 @@
+@prefix :         <http://fairdatapoint.org/> .
+@prefix dash:     <http://datashapes.org/dash#> .
+@prefix dcat:     <http://www.w3.org/ns/dcat#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix sh:       <http://www.w3.org/ns/shacl#> .
+
+:DistributionShape a sh:NodeShape ;
+  sh:targetClass dcat:Distribution ;
+  sh:property [
+    sh:path dct:issued ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:editor dash:DatePickerEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dct:modified ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:editor dash:DatePickerEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dcat:accessURL ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+  ], [
+    sh:path dcat:downloadURL ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+  ], [
+    sh:path dcat:mediaType ;
+    sh:nodeKind sh:Literal ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    dash:editor dash:TextFieldEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dcat:format ;
+    sh:nodeKind sh:Literal ;
+    sh:maxCount 1 ;
+    dash:editor dash:TextFieldEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dcat:byteSize ;
+    sh:nodeKind sh:Literal ;
+    sh:maxCount 1 ;
+    dash:editor dash:TextFieldEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ] .

--- a/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-repository.ttl
+++ b/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-repository.ttl
@@ -1,0 +1,40 @@
+@prefix :         <http://fairdatapoint.org/> .
+@prefix dash:     <http://datashapes.org/dash#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix r3d:      <http://www.re3data.org/schema/3-0#> .
+@prefix sh:       <http://www.w3.org/ns/shacl#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+
+:RepositoryShape a sh:NodeShape ;
+  sh:targetClass r3d:Repository ;
+  sh:property [
+    sh:path dct:references ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path r3d:institution ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path r3d:startDate ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:editor dash:DatePickerEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path r3d:lastUpdate ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+    dash:editor dash:DatePickerEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path r3d:institutionCountry ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ] .

--- a/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-resource.ttl
+++ b/src/main/resources/nl/dtls/fairdatapoint/service/reset/shape-resource.ttl
@@ -1,0 +1,64 @@
+@prefix :         <http://fairdatapoint.org/> .
+@prefix dash:     <http://datashapes.org/dash#> .
+@prefix dcat:     <http://www.w3.org/ns/dcat#> .
+@prefix dct:      <http://purl.org/dc/terms/> .
+@prefix foaf:     <http://xmlns.com/foaf/0.1/> .
+@prefix sh:       <http://www.w3.org/ns/shacl#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+
+:ResourceShape a sh:NodeShape ;
+  sh:targetClass dcat:Resource ;
+  sh:property [
+    sh:path dct:title ;
+    sh:nodeKind sh:Literal ;
+    sh:minCount 1 ;
+    sh:maxCount  1 ;
+    dash:editor dash:TextFieldEditor ;
+  ], [
+    sh:path dct:description ;
+    sh:nodeKind sh:Literal ;
+    sh:maxCount 1 ;
+    dash:editor dash:TextAreaEditor ;
+  ], [
+    sh:path dct:publisher ;
+    sh:node :AgentShape ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    dash:editor dash:BlankNodeEditor ;
+  ], [
+    sh:path dct:hasVersion ;
+    sh:name "version" ;
+    sh:nodeKind sh:Literal ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    dash:editor dash:TextFieldEditor ;
+    dash:viewer dash:LiteralViewer ;
+  ], [
+    sh:path dct:language ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path dct:license ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ], [
+    sh:path dct:rights ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    dash:editor dash:URIEditor ;
+    dash:viewer dash:LabelViewer ;
+  ] .
+
+:AgentShape a sh:NodeShape ;
+  sh:targetClass foaf:Agent ;
+  sh:property [
+    sh:path foaf:name ;
+    sh:nodeKind sh:Literal ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    dash:editor dash:TextFieldEditor ;
+  ] .


### PR DESCRIPTION
This allows admins to trigger reset of FDP data:

- users (including permissions given to metadata and API keys)
- metadata (including permissions)
- resource definitions (including SHACL shapes and metadata)