### PR TITLE
Upgrade to Java 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
       PRIVATE_IMAGE: ${{ secrets.PRIVATE_REGISTRY_URL }}/fairdatapoint
       TAG_DEVELOP: develop
       TAG_LATEST: latest
-      JDK_VERSION: 15
-      JDK_FILE: openjdk-15.0.2_linux-x64_bin.tar.gz
-      JDK_URL: https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz
+      JDK_VERSION: 16
+      JDK_FILE: openjdk-16.0.1_linux-x64_bin.tar.gz
+      JDK_URL: https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz
 
     services:
       mongo:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade Java JDK from 15 to 16
+
 ## [1.9.0]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 #
 
-FROM openjdk:15-jdk-slim
+FROM openjdk:16-jdk-slim
 
 WORKDIR /fdp
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -22,7 +22,7 @@
 #
 ################################################################################
 # BUILD STAGE
-FROM maven:3-openjdk-15 as builder
+FROM maven:3-openjdk-16 as builder
 
 WORKDIR /builder
 
@@ -32,7 +32,7 @@ RUN mvn --quiet -B -U --fail-fast -DskipTests package
 
 ################################################################################
 # RUN STAGE
-FROM openjdk:15-jdk-slim
+FROM openjdk:16-jdk-slim
 
 WORKDIR /fdp
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ e.g. [app.fairdatapoint.org/swagger-ui.html](https://app.fairdatapoint.org/swagg
 
 ### Technology Stack
 
-- **Java** (JDK 15)
+- **Java** (JDK 16)
 - **MongoDB** (4.2)
 - **Maven** (3.2.5 or higher)
 - **Docker** (17.09.0-ce or higher) - *for building Docker image only*

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Maven -->
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
 
         <!-- Project related -->
         <spring.rdf.migration.version>1.1.0.RELEASE</spring.rdf.migration.version>


### PR DESCRIPTION
Java SE 15 support ended in March 2021. Java SE 16 will be supported till September 2021 and then we can finally switch to LTS (Java 17) that will have extended support for several years (TBA).