### PR TITLE
[FDP-550] Use profile for conformsTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Allow to change internal shapes
 - Reset to "factory defaults" (users, resource definitions, metadata)
+- All metadata have dct:conformsTo with profile based on resource definition
 
 ### Changed
 
 - Upgrade Java JDK from 15 to 16
+- Resource definitions are related directly to shapes
 
 ## [1.9.0]
 

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/resource/ResourceDefinitionController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/resource/ResourceDefinitionController.java
@@ -24,8 +24,8 @@ package nl.dtls.fairdatapoint.api.controller.resource;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
+import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
 import nl.dtls.fairdatapoint.entity.exception.ResourceNotFoundException;
-import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -49,21 +49,21 @@ public class ResourceDefinitionController {
     private ResourceDefinitionService resourceDefinitionService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<ResourceDefinition>> getResourceDefinitions() {
-        List<ResourceDefinition> dto = resourceDefinitionService.getAll();
+    public ResponseEntity<List<ResourceDefinitionDTO>> getResourceDefinitions() {
+        List<ResourceDefinitionDTO> dto = resourceDefinitionService.getAll();
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ResourceDefinition> createResourceDefinitions(@RequestBody @Valid ResourceDefinitionChangeDTO reqDto) throws BindException {
-        ResourceDefinition dto = resourceDefinitionService.create(reqDto);
+    public ResponseEntity<ResourceDefinitionDTO> createResourceDefinitions(@RequestBody @Valid ResourceDefinitionChangeDTO reqDto) throws BindException {
+        ResourceDefinitionDTO dto = resourceDefinitionService.create(reqDto);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     @GetMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ResourceDefinition> getResourceDefinition(@PathVariable final String uuid)
+    public ResponseEntity<ResourceDefinitionDTO> getResourceDefinition(@PathVariable final String uuid)
             throws ResourceNotFoundException {
-        Optional<ResourceDefinition> oDto = resourceDefinitionService.getByUuid(uuid);
+        Optional<ResourceDefinitionDTO> oDto = resourceDefinitionService.getDTOByUuid(uuid);
         if (oDto.isPresent()) {
             return new ResponseEntity<>(oDto.get(), HttpStatus.OK);
         } else {
@@ -72,10 +72,10 @@ public class ResourceDefinitionController {
     }
 
     @PutMapping(path = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ResourceDefinition> putResourceDefinitions(@PathVariable final String uuid,
+    public ResponseEntity<ResourceDefinitionDTO> putResourceDefinitions(@PathVariable final String uuid,
                                                                      @RequestBody @Valid ResourceDefinitionChangeDTO reqDto)
             throws ResourceNotFoundException, BindException {
-        Optional<ResourceDefinition> oDto = resourceDefinitionService.update(uuid, reqDto);
+        Optional<ResourceDefinitionDTO> oDto = resourceDefinitionService.update(uuid, reqDto);
         if (oDto.isPresent()) {
             return new ResponseEntity<>(oDto.get(), HttpStatus.OK);
         } else {

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/resource/ResourceDefinitionChangeDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/resource/ResourceDefinitionChangeDTO.java
@@ -48,7 +48,7 @@ public class ResourceDefinitionChangeDTO {
     protected String urlPrefix;
 
     @NotNull
-    protected List<@ValidIri String> targetClassUris;
+    protected List<String> shapeUuids;
 
     @NotNull
     @Valid

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/resource/ResourceDefinitionDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/resource/ResourceDefinitionDTO.java
@@ -20,27 +20,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package nl.dtls.fairdatapoint.api.dto.config;
+package nl.dtls.fairdatapoint.api.dto.resource;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
-import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinitionChild;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinitionLink;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
-public class BootstrapConfigDTO {
+public class ResourceDefinitionDTO {
 
-    protected String persistentUrl;
+    @NotBlank
+    private String uuid;
 
-    protected List<ResourceDefinitionDTO> resourceDefinitions;
+    @NotBlank
+    protected String name;
 
-    protected boolean index;
+    @NotNull
+    protected String urlPrefix;
 
+    @NotNull
+    protected List<String> shapeUuids;
+
+    @NotNull
+    protected List<String> targetClassUris;
+
+    @NotNull
+    @Valid
+    protected List<ResourceDefinitionChild> children;
+
+    @NotNull
+    @Valid
+    protected List<ResourceDefinitionLink> externalLinks;
 }

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/shape/ShapeDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/shape/ShapeDTO.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import nl.dtls.fairdatapoint.entity.shape.ShapeType;
 
+import java.util.List;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -44,4 +46,5 @@ public class ShapeDTO {
 
     private String definition;
 
+    private List<String> targetClasses;
 }

--- a/src/main/java/nl/dtls/fairdatapoint/config/CacheConfig.java
+++ b/src/main/java/nl/dtls/fairdatapoint/config/CacheConfig.java
@@ -41,6 +41,8 @@ public class CacheConfig {
 
     public static final String RESOURCE_DEFINITION_PARENT_CACHE = "RESOURCE_DEFINITION_PARENT_CACHE";
 
+    public static final String RESOURCE_DEFINITION_TARGET_CLASSES_CACHE = "RESOURCE_DEFINITION_TARGET_CLASSES_CACHE";
+
     @Bean
     public ConcurrentMapCacheManager cacheManager() {
         ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
@@ -48,7 +50,8 @@ public class CacheConfig {
                 ACL_CACHE,
                 CATALOG_THEMES_CACHE,
                 RESOURCE_DEFINITION_CACHE,
-                RESOURCE_DEFINITION_PARENT_CACHE
+                RESOURCE_DEFINITION_PARENT_CACHE,
+                RESOURCE_DEFINITION_TARGET_CLASSES_CACHE
         ));
         return cacheManager;
     }

--- a/src/main/java/nl/dtls/fairdatapoint/config/MongoConfig.java
+++ b/src/main/java/nl/dtls/fairdatapoint/config/MongoConfig.java
@@ -26,6 +26,7 @@ import com.github.cloudyrock.mongock.config.LegacyMigration;
 import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
 import com.github.cloudyrock.spring.v5.MongockSpring5;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionCache;
+import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionTargetClassesCache;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,9 @@ public class MongoConfig {
     @Autowired
     private ResourceDefinitionCache resourceDefinitionCache;
 
+    @Autowired
+    private ResourceDefinitionTargetClassesCache targetClassesCache;
+
     @Bean("mongockRunner")
     public MongockSpring5.MongockApplicationRunner mongockApplicationRunner(
             ApplicationContext springContext,
@@ -52,6 +56,7 @@ public class MongoConfig {
                 .setSpringContext(springContext)
                 .setLegacyMigration(new LegacyMigration("dbchangelog"))
                 .addDependency(ResourceDefinitionCache.class, resourceDefinitionCache)
+                .addDependency(ResourceDefinitionTargetClassesCache.class, targetClassesCache)
                 .buildApplicationRunner();
     }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/resource/data/ResourceDefinitionFixtures.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/resource/data/ResourceDefinitionFixtures.java
@@ -22,6 +22,7 @@
  */
 package nl.dtls.fairdatapoint.database.mongo.migration.development.resource.data;
 
+import nl.dtls.fairdatapoint.database.mongo.migration.development.shape.data.ShapeFixtures;
 import nl.dtls.fairdatapoint.entity.resource.*;
 import nl.dtls.fairdatapoint.vocabulary.R3D;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
@@ -47,7 +48,7 @@ public class ResourceDefinitionFixtures {
                 REPOSITORY_DEFINITION_UUID,
                 "Repository",
                 "",
-                List.of("http://www.w3.org/ns/dcat#Resource", "http://www.re3data.org/schema/3-0#Repository"),
+                List.of(ShapeFixtures.RESOURCE_SHAPE_UUID, ShapeFixtures.REPOSITORY_SHAPE_UUID),
                 List.of(new ResourceDefinitionChild(
                         CATALOG_DEFINITION_UUID,
                         R3D.DATACATALOG.stringValue(),
@@ -66,7 +67,7 @@ public class ResourceDefinitionFixtures {
                 CATALOG_DEFINITION_UUID,
                 "Catalog",
                 "catalog",
-                List.of("http://www.w3.org/ns/dcat#Resource", "http://www.w3.org/ns/dcat#Catalog"),
+                List.of(ShapeFixtures.RESOURCE_SHAPE_UUID, ShapeFixtures.CATALOG_SHAPE_UUID),
                 List.of(new ResourceDefinitionChild(
                         DATASET_DEFINITION_UUID,
                         DCAT.HAS_DATASET.stringValue(),
@@ -85,7 +86,7 @@ public class ResourceDefinitionFixtures {
                 DATASET_DEFINITION_UUID,
                 "Dataset",
                 "dataset",
-                List.of("http://www.w3.org/ns/dcat#Resource", "http://www.w3.org/ns/dcat#Dataset"),
+                List.of(ShapeFixtures.RESOURCE_SHAPE_UUID, ShapeFixtures.DATASET_SHAPE_UUID),
                 List.of(new ResourceDefinitionChild(
                         DISTRIBUTION_DEFINITION_UUID,
                         DCAT.HAS_DISTRIBUTION.stringValue(),
@@ -105,7 +106,7 @@ public class ResourceDefinitionFixtures {
                 DISTRIBUTION_DEFINITION_UUID,
                 "Distribution",
                 "distribution",
-                List.of("http://www.w3.org/ns/dcat#Resource", "http://www.w3.org/ns/dcat#Distribution"),
+                List.of(ShapeFixtures.RESOURCE_SHAPE_UUID, ShapeFixtures.DISTRIBUTION_SHAPE_UUID),
                 List.of(),
                 List.of(
                         new ResourceDefinitionLink("Access online", "http://www.w3.org/ns/dcat#accessURL"),
@@ -119,7 +120,7 @@ public class ResourceDefinitionFixtures {
                 ONTOLOGY_DEFINITION_UUID,
                 "Ontology",
                 "ontology",
-                List.of("http://www.w3.org/ns/dcat#Resource", "http://www.w3.org/ns/dcat#Ontology"),
+                List.of(ShapeFixtures.RESOURCE_SHAPE_UUID),
                 List.of(),
                 List.of()
         );

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/shape/data/ShapeFixtures.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/shape/data/ShapeFixtures.java
@@ -26,8 +26,20 @@ import nl.dtls.fairdatapoint.entity.shape.Shape;
 import nl.dtls.fairdatapoint.entity.shape.ShapeType;
 import org.springframework.stereotype.Service;
 
+import java.util.Set;
+
 @Service
 public class ShapeFixtures {
+
+    public static final String RESOURCE_SHAPE_UUID = "6a668323-3936-4b53-8380-a4fd2ed082ee";
+
+    public static final String REPOSITORY_SHAPE_UUID = "a92958ab-a414-47e6-8e17-68ba96ba3a2b";
+
+    public static final String CATALOG_SHAPE_UUID = "2aa7ba63-d27a-4c0e-bfa6-3a4e250f4660";
+
+    public static final String DATASET_SHAPE_UUID = "866d7fb8-5982-4215-9c7c-18d0ed1bd5f3";
+
+    public static final String DISTRIBUTION_SHAPE_UUID = "ebacbf83-cd4f-4113-8738-d73c0735b0ab";
 
     public Shape resourceShape() {
         return new Shape(
@@ -99,7 +111,8 @@ public class ShapeFixtures {
                         "    sh:minCount 1 ;\n" +
                         "    sh:maxCount  1 ;\n" +
                         "    dash:editor dash:TextFieldEditor ;\n" +
-                        "  ] ."
+                        "  ] .",
+                Set.of("http://www.w3.org/ns/dcat#Resource")
         );
     }
 
@@ -149,7 +162,8 @@ public class ShapeFixtures {
                         "    sh:maxCount 1 ;\n" +
                         "    dash:editor dash:URIEditor ;\n" +
                         "    dash:viewer dash:LabelViewer ;\n" +
-                        "  ] .\n"
+                        "  ] .\n",
+                Set.of("http://www.w3.org/ns/dcat#Repository")
         );
     }
 
@@ -189,7 +203,8 @@ public class ShapeFixtures {
                         "    sh:path dcat:themeTaxonomy ;\n" +
                         "    sh:nodeKind sh:IRI ;\n" +
                         "    dash:viewer dash:LabelViewer ;\n" +
-                        "  ] .\n"
+                        "  ] .\n",
+                Set.of("http://www.w3.org/ns/dcat#Catalog")
         );
     }
 
@@ -243,7 +258,8 @@ public class ShapeFixtures {
                         "    sh:maxCount 1 ;\n" +
                         "    dash:editor dash:URIEditor ;\n" +
                         "    dash:viewer dash:LabelViewer ;\n" +
-                        "  ] .\n"
+                        "  ] .\n",
+                Set.of("http://www.w3.org/ns/dcat#Dataset")
         );
     }
 
@@ -303,7 +319,8 @@ public class ShapeFixtures {
                         "    sh:maxCount 1 ;\n" +
                         "    dash:editor dash:TextFieldEditor ;\n" +
                         "    dash:viewer dash:LiteralViewer ;\n" +
-                        "  ] ."
+                        "  ] .",
+                Set.of("http://www.w3.org/ns/dcat#Distribution")
         );
     }
 
@@ -326,7 +343,8 @@ public class ShapeFixtures {
                         "      sh:nodeKind sh:IRI ;\n" +
                         "      dash:editor dash:URIEditor ;\n" +
                         "      dash:viewer dash:LabelViewer ;\n" +
-                        "    ] ."
+                        "    ] .",
+                Set.of("http://example.org/Dog")
         );
     }
 
@@ -355,7 +373,8 @@ public class ShapeFixtures {
                         "      sh:nodeKind sh:Literal ;\n" +
                         "      dash:editor dash:TextFieldEditor ;\n" +
                         "      dash:viewer dash:LiteralViewer ;\n" +
-                        "    ] ."
+                        "    ] .",
+                Set.of("http://example.org/Dog")
         );
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/production/Migration_0009_ShapeTargetClasses.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/production/Migration_0009_ShapeTargetClasses.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package nl.dtls.fairdatapoint.database.mongo.migration.production;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import nl.dtls.fairdatapoint.Profiles;
+import nl.dtls.fairdatapoint.service.shape.ShapeShaclUtils;
+import org.bson.Document;
+import org.springframework.context.annotation.Profile;
+
+import java.util.*;
+
+@ChangeLog(order = "0009")
+@Profile(Profiles.PRODUCTION)
+public class Migration_0009_ShapeTargetClasses {
+
+    @ChangeSet(order = "0009", id = "Migration_0009_ShapeTargetClasses", author = "migrationBot")
+    public void run(MongoDatabase db) {
+        updateShapesAndResources(db);
+    }
+
+    private void updateShapesAndResources(MongoDatabase db) {
+        Map<String, Set<String>> targetClassesMap = new HashMap<>();
+        // Update shapes
+        MongoCollection<Document> shapeCol = db.getCollection("shape");
+        for (Document document : shapeCol.find()) {
+            String definition = (String) document.get("definition");
+            String uuid = (String) document.get("uuid");
+            Set<String> targetClasses = ShapeShaclUtils.extractTargetClasses(definition);
+            targetClassesMap.put(uuid, targetClasses);
+            shapeCol.updateOne(
+                    Filters.eq("uuid", uuid),
+                    Updates.set("targetClasses", targetClasses)
+            );
+        }
+        // Update resource definitions
+        MongoCollection<Document> rdCol = db.getCollection("resourceDefinition");
+        for (Document document : rdCol.find()) {
+            List<String> targetClassUris = (List<String>) document.get("targetClassUris");
+            Set<String> shapeUuids = new HashSet<>();
+            targetClassUris.forEach(uri -> {
+                targetClassesMap.forEach((shapeUuid, targetClasses) -> {
+                    if (targetClasses.contains(uri)) {
+                        shapeUuids.add(shapeUuid);
+                    }
+                });
+            });
+            rdCol.updateOne(
+                    Filters.eq("uuid", document.get("uuid")),
+                    Updates.unset("targetClassUris")
+            );
+            rdCol.updateOne(
+                    Filters.eq("uuid", document.get("uuid")),
+                    Updates.set("shapeUuids", shapeUuids)
+            );
+        }
+    }
+}

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/repository/ResourceDefinitionRepository.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/repository/ResourceDefinitionRepository.java
@@ -25,6 +25,7 @@ package nl.dtls.fairdatapoint.database.mongo.repository;
 import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ResourceDefinitionRepository extends MongoRepository<ResourceDefinition, String> {
@@ -34,5 +35,7 @@ public interface ResourceDefinitionRepository extends MongoRepository<ResourceDe
     Optional<ResourceDefinition> findByName(String name);
 
     Optional<ResourceDefinition> findByUrlPrefix(String urlPrefix);
+
+    List<ResourceDefinition> findByShapeUuidsIsContaining(String shapeUuid);
 
 }

--- a/src/main/java/nl/dtls/fairdatapoint/entity/resource/ResourceDefinition.java
+++ b/src/main/java/nl/dtls/fairdatapoint/entity/resource/ResourceDefinition.java
@@ -50,18 +50,18 @@ public class ResourceDefinition {
 
     protected String urlPrefix;
 
-    protected List<String> targetClassUris = new ArrayList<>();
+    protected List<String> shapeUuids = new ArrayList<>();
 
     protected List<ResourceDefinitionChild> children = new ArrayList<>();
 
     protected List<ResourceDefinitionLink> externalLinks = new ArrayList<>();
 
-    public ResourceDefinition(String uuid, String name, String urlPrefix, List<String> targetClassUris,
+    public ResourceDefinition(String uuid, String name, String urlPrefix, List<String> shapeUuids,
                               List<ResourceDefinitionChild> children, List<ResourceDefinitionLink> externalLinks) {
         this.uuid = uuid;
         this.name = name;
         this.urlPrefix = urlPrefix;
-        this.targetClassUris = targetClassUris;
+        this.shapeUuids = shapeUuids;
         this.children = children;
         this.externalLinks = externalLinks;
     }

--- a/src/main/java/nl/dtls/fairdatapoint/entity/shape/Shape.java
+++ b/src/main/java/nl/dtls/fairdatapoint/entity/shape/Shape.java
@@ -27,6 +27,8 @@ import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.Set;
+
 @Document
 @Getter
 @Setter
@@ -48,4 +50,5 @@ public class Shape {
 
     private String definition;
 
+    private Set<String> targetClasses;
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/config/ConfigService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/config/ConfigService.java
@@ -23,8 +23,8 @@
 package nl.dtls.fairdatapoint.service.config;
 
 import nl.dtls.fairdatapoint.api.dto.config.BootstrapConfigDTO;
-import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionRepository;
-import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
+import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,10 +43,10 @@ public class ConfigService {
     private boolean index;
 
     @Autowired
-    private ResourceDefinitionRepository resourceDefinitionRepository;
+    private ResourceDefinitionService resourceDefinitionService;
 
     public BootstrapConfigDTO getBootstrapConfig() {
-        List<ResourceDefinition> resourceDefinitions = resourceDefinitionRepository.findAll();
+        List<ResourceDefinitionDTO> resourceDefinitions = resourceDefinitionService.getAll();
         return new BootstrapConfigDTO(persistentUrl, resourceDefinitions, index);
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/metadata/validator/MetadataValidator.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/metadata/validator/MetadataValidator.java
@@ -29,6 +29,7 @@ import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import nl.dtls.fairdatapoint.service.metadata.exception.MetadataServiceException;
 import nl.dtls.fairdatapoint.service.rdf.ShaclValidator;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionCache;
+import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionService;
 import nl.dtls.fairdatapoint.service.shape.ShapeService;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
@@ -56,6 +57,9 @@ public class MetadataValidator {
     @Autowired
     private ResourceDefinitionCache resourceDefinitionCache;
 
+    @Autowired
+    private ResourceDefinitionService resourceDefinitionService;
+
     public void validate(Model metadata, IRI uri, ResourceDefinition rd) throws MetadataServiceException {
         validateByShacl(metadata, uri);
         if (!rd.getName().equals("Repository")) {
@@ -79,7 +83,7 @@ public class MetadataValidator {
         try {
             ResourceDefinition rdParent = resourceDefinitionCache.getParentByUuid(rd.getUuid());
             if (rdParent != null) {
-                for (String rdfType : rdParent.getTargetClassUris()) {
+                for (String rdfType : resourceDefinitionService.getTargetClassUris(rdParent)) {
                     if (!metadataRepository.checkExistence(parent, RDF.TYPE, i(rdfType))) {
                         throw new ValidationException("Parent is not of correct type");
                     }

--- a/src/main/java/nl/dtls/fairdatapoint/service/reset/FactoryDefaults.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/reset/FactoryDefaults.java
@@ -33,6 +33,7 @@ import nl.dtls.fairdatapoint.entity.shape.Shape;
 import nl.dtls.fairdatapoint.entity.shape.ShapeType;
 import nl.dtls.fairdatapoint.entity.user.User;
 import nl.dtls.fairdatapoint.entity.user.UserRole;
+import nl.dtls.fairdatapoint.service.shape.ShapeShaclUtils;
 import nl.dtls.fairdatapoint.vocabulary.DATACITE;
 import nl.dtls.fairdatapoint.vocabulary.FDP;
 import nl.dtls.fairdatapoint.vocabulary.R3D;
@@ -108,15 +109,26 @@ public class FactoryDefaults {
             ))
             .build();
 
+    //== SHAPE UUIDS
+    private static final String SHAPE_RESOURCE_UUID = "6a668323-3936-4b53-8380-a4fd2ed082ee";
+
+    private static final String SHAPE_REPOSITORY_UUID = "a92958ab-a414-47e6-8e17-68ba96ba3a2b";
+
+    private static final String SHAPE_CATALOG_UUID = "2aa7ba63-d27a-4c0e-bfa6-3a4e250f4660";
+
+    private static final String SHAPE_DATASET_UUID = "866d7fb8-5982-4215-9c7c-18d0ed1bd5f3";
+
+    private static final String SHAPE_DISTRIBUTION_UUID = "ebacbf83-cd4f-4113-8738-d73c0735b0ab";
+
     //== RESOURCE DEFINITIONS
     // Changes: Migration_0002_CustomMetamodel, Migration_0004_ResourceDefinition
     public static final ResourceDefinition RESOURCE_DEFINITION_REPOSITORY = ResourceDefinition.builder()
             .uuid("77aaad6a-0136-4c6e-88b9-07ffccd0ee4c")
             .name("Repository")
             .urlPrefix("")
-            .targetClassUris(List.of(
-                    "http://www.w3.org/ns/dcat#Resource",
-                    "http://www.re3data.org/schema/3-0#Repository"
+            .shapeUuids(List.of(
+                    SHAPE_RESOURCE_UUID,
+                    SHAPE_REPOSITORY_UUID
             ))
             .children(List.of(
                     ResourceDefinitionChild.builder()
@@ -138,9 +150,9 @@ public class FactoryDefaults {
             .uuid("a0949e72-4466-4d53-8900-9436d1049a4b")
             .name("Catalog")
             .urlPrefix("catalog")
-            .targetClassUris(List.of(
-                    "http://www.w3.org/ns/dcat#Resource",
-                    "http://www.w3.org/ns/dcat#Catalog"
+            .shapeUuids(List.of(
+                    SHAPE_RESOURCE_UUID,
+                    SHAPE_CATALOG_UUID
             ))
             .children(List.of(
                     ResourceDefinitionChild.builder()
@@ -162,9 +174,9 @@ public class FactoryDefaults {
             .uuid("2f08228e-1789-40f8-84cd-28e3288c3604")
             .name("Dataset")
             .urlPrefix("dataset")
-            .targetClassUris(List.of(
-                    "http://www.w3.org/ns/dcat#Resource",
-                    "http://www.w3.org/ns/dcat#Dataset"
+            .shapeUuids(List.of(
+                    SHAPE_RESOURCE_UUID,
+                    SHAPE_DATASET_UUID
             ))
             .children(List.of(
                     ResourceDefinitionChild.builder()
@@ -187,13 +199,13 @@ public class FactoryDefaults {
             .externalLinks(List.of())
             .build();
 
-    public static final ResourceDefinition RESOURCE_DEFINITION_DISTRIBUTION = ResourceDefinition.builder()
+    public static ResourceDefinition RESOURCE_DEFINITION_DISTRIBUTION = ResourceDefinition.builder()
             .uuid("02c649de-c579-43bb-b470-306abdc808c7")
             .name("Distribution")
             .urlPrefix("distribution")
-            .targetClassUris(List.of(
-                    "http://www.w3.org/ns/dcat#Resource",
-                    "http://www.w3.org/ns/dcat#Distribution"
+            .shapeUuids(List.of(
+                    SHAPE_RESOURCE_UUID,
+                    SHAPE_DISTRIBUTION_UUID
             ))
             .children(List.of())
             .externalLinks(List.of(
@@ -211,52 +223,62 @@ public class FactoryDefaults {
     //== SHAPES
     //== Changes: Migration_0003_ShapeDefinition, Migration_0005_UpdateShapeDefinition, Migration_0006_ShapesSharing
     public static Shape shapeResource() throws Exception {
+        String definition = loadShape("shape-resource.ttl");
         return Shape.builder()
-                .uuid("6a668323-3936-4b53-8380-a4fd2ed082ee")
+                .uuid(SHAPE_RESOURCE_UUID)
                 .name("Resource")
                 .type(ShapeType.INTERNAL)
                 .published(false)
-                .definition(loadShape("shape-resource.ttl"))
+                .definition(definition)
+                .targetClasses(ShapeShaclUtils.extractTargetClasses(definition))
                 .build();
     }
 
     public static Shape shapeRepository() throws Exception {
+        String definition = loadShape("shape-repository.ttl");
         return Shape.builder()
-                .uuid("a92958ab-a414-47e6-8e17-68ba96ba3a2b")
+                .uuid(SHAPE_REPOSITORY_UUID)
                 .name("Repository")
                 .type(ShapeType.INTERNAL)
                 .published(false)
-                .definition(loadShape("shape-repository.ttl"))
+                .definition(definition)
+                .targetClasses(ShapeShaclUtils.extractTargetClasses(definition))
                 .build();
     }
 
     public static Shape shapeCatalog() throws Exception {
+        String definition = loadShape("shape-catalog.ttl");
         return Shape.builder()
-                .uuid("2aa7ba63-d27a-4c0e-bfa6-3a4e250f4660")
+                .uuid(SHAPE_CATALOG_UUID)
                 .name("Catalog")
                 .type(ShapeType.INTERNAL)
                 .published(false)
-                .definition(loadShape("shape-catalog.ttl"))
+                .definition(definition)
+                .targetClasses(ShapeShaclUtils.extractTargetClasses(definition))
                 .build();
     }
 
     public static Shape shapeDataset() throws Exception {
+        String definition = loadShape("shape-dataset.ttl");
         return Shape.builder()
-                .uuid("866d7fb8-5982-4215-9c7c-18d0ed1bd5f3")
+                .uuid(SHAPE_DATASET_UUID)
                 .name("Dataset")
                 .type(ShapeType.CUSTOM)
                 .published(false)
-                .definition(loadShape("shape-dataset.ttl"))
+                .definition(definition)
+                .targetClasses(ShapeShaclUtils.extractTargetClasses(definition))
                 .build();
     }
 
     public static Shape shapeDistribution() throws Exception {
+        String definition = loadShape("shape-distribution.ttl");
         return Shape.builder()
-                .uuid("ebacbf83-cd4f-4113-8738-d73c0735b0ab")
+                .uuid(SHAPE_DISTRIBUTION_UUID)
                 .name("Distribution")
                 .type(ShapeType.CUSTOM)
                 .published(false)
-                .definition(loadShape("shape-distribution.ttl"))
+                .definition(definition)
+                .targetClasses(ShapeShaclUtils.extractTargetClasses(definition))
                 .build();
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionMapper.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionMapper.java
@@ -23,8 +23,11 @@
 package nl.dtls.fairdatapoint.service.resource;
 
 import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
+import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
 import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class ResourceDefinitionMapper {
@@ -34,7 +37,7 @@ public class ResourceDefinitionMapper {
                 uuid,
                 dto.getName(),
                 dto.getUrlPrefix(),
-                dto.getTargetClassUris(),
+                dto.getShapeUuids(),
                 dto.getChildren(),
                 dto.getExternalLinks());
     }
@@ -43,8 +46,20 @@ public class ResourceDefinitionMapper {
         return new ResourceDefinitionChangeDTO(
                 rd.getName(),
                 rd.getUrlPrefix(),
-                rd.getTargetClassUris(),
+                rd.getShapeUuids(),
                 rd.getChildren(),
                 rd.getExternalLinks());
+    }
+
+    public ResourceDefinitionDTO toDTO(ResourceDefinition rd, List<String> targetClassUris) {
+        return new ResourceDefinitionDTO(
+                rd.getUuid(),
+                rd.getName(),
+                rd.getUrlPrefix(),
+                rd.getShapeUuids(),
+                targetClassUris,
+                rd.getChildren(),
+                rd.getExternalLinks()
+        );
     }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionService.java
@@ -23,6 +23,7 @@
 package nl.dtls.fairdatapoint.service.resource;
 
 import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
+import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
 import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionRepository;
 import nl.dtls.fairdatapoint.entity.exception.ResourceNotFoundException;
 import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
@@ -33,6 +34,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.BindException;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -56,17 +58,32 @@ public class ResourceDefinitionService {
     private ResourceDefinitionCache resourceDefinitionCache;
 
     @Autowired
+    private ResourceDefinitionTargetClassesCache targetClassesCache;
+
+    @Autowired
     private MembershipService membershipService;
 
     @Autowired
     private OpenApiService openApiService;
 
-    public List<ResourceDefinition> getAll() {
-        return resourceDefinitionRepository.findAll();
+    public ResourceDefinitionDTO toDTO(ResourceDefinition rd) {
+        return resourceDefinitionMapper.toDTO(rd, getTargetClassUris(rd));
+    }
+
+    public List<ResourceDefinitionDTO> getAll() {
+        return resourceDefinitionRepository
+                .findAll()
+                .stream()
+                .map(this::toDTO)
+                .toList();
     }
 
     public Optional<ResourceDefinition> getByUuid(String uuid) {
         return resourceDefinitionRepository.findByUuid(uuid);
+    }
+
+    public Optional<ResourceDefinitionDTO> getDTOByUuid(String uuid) {
+        return getByUuid(uuid).map(this::toDTO);
     }
 
     public ResourceDefinition getByUrlPrefix(String urlPrefix) {
@@ -80,21 +97,24 @@ public class ResourceDefinitionService {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    public ResourceDefinition create(ResourceDefinitionChangeDTO reqDto) throws BindException {
+    public ResourceDefinitionDTO create(ResourceDefinitionChangeDTO reqDto) throws BindException {
         String uuid = UUID.randomUUID().toString();
         ResourceDefinition rd = resourceDefinitionMapper.fromChangeDTO(reqDto, uuid);
+
+        // TODO: check if shapes exist
 
         resourceDefinitionValidator.validate(rd);
         resourceDefinitionRepository.save(rd);
         resourceDefinitionCache.computeCache();
+        targetClassesCache.computeCache();
 
         membershipService.addToMembership(rd);
         openApiService.updateGenericPaths(rd);
-        return rd;
+        return toDTO(rd);
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    public Optional<ResourceDefinition> update(String uuid, ResourceDefinitionChangeDTO reqDto) throws BindException {
+    public Optional<ResourceDefinitionDTO> update(String uuid, ResourceDefinitionChangeDTO reqDto) throws BindException {
         Optional<ResourceDefinition> oRd = resourceDefinitionRepository.findByUuid(uuid);
         if (oRd.isEmpty()) {
             return Optional.empty();
@@ -103,11 +123,14 @@ public class ResourceDefinitionService {
         ResourceDefinition updatedRd = resourceDefinitionMapper.fromChangeDTO(reqDto, rd.getUuid());
         updatedRd.setId(rd.getId());
 
+        // TODO: check if shapes exist
+
         resourceDefinitionValidator.validate(updatedRd);
         resourceDefinitionRepository.save(updatedRd);
         resourceDefinitionCache.computeCache();
+        targetClassesCache.computeCache();
         openApiService.updateGenericPaths(updatedRd);
-        return Optional.of(updatedRd);
+        return Optional.of(updatedRd).map(this::toDTO);
     }
 
     @PreAuthorize("hasRole('ADMIN')")
@@ -140,10 +163,19 @@ public class ResourceDefinitionService {
 
         // 5. Recompute cache
         resourceDefinitionCache.computeCache();
+        targetClassesCache.computeCache();
 
         // 6. Delete from OpenAPI docs
         openApiService.removeGenericPaths(rd);
         return true;
     }
 
+    public List<String> getTargetClassUris(ResourceDefinition rd) {
+        List<String> result = targetClassesCache.getByUuid(rd.getUuid());
+        if (result == null) {
+            targetClassesCache.computeCache();
+            return targetClassesCache.getByUuid(rd.getUuid());
+        }
+        return result;
+    }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionTargetClassesCache.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionTargetClassesCache.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package nl.dtls.fairdatapoint.service.resource;
+
+import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionRepository;
+import nl.dtls.fairdatapoint.database.mongo.repository.ShapeRepository;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import nl.dtls.fairdatapoint.entity.shape.Shape;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static nl.dtls.fairdatapoint.config.CacheConfig.RESOURCE_DEFINITION_TARGET_CLASSES_CACHE;
+
+@Service
+public class ResourceDefinitionTargetClassesCache {
+
+    @Autowired
+    private ConcurrentMapCacheManager cacheManager;
+
+    @Autowired
+    private ResourceDefinitionRepository resourceDefinitionRepository;
+
+    @Autowired
+    private ShapeRepository shapeRepository;
+
+    @PostConstruct
+    public void computeCache() {
+        // Get cache
+        Cache cache = cache();
+
+        // Clear cache
+        cache.clear();
+
+        // Add to cache
+        List<ResourceDefinition> rds = resourceDefinitionRepository.findAll();
+        Map<String, Shape> shapes = shapeRepository.findAll().stream().collect(Collectors.toMap(Shape::getUuid, Function.identity()));
+        rds.forEach(rd -> {
+            Set<String> targetClassUris = new HashSet<>();
+            rd.getShapeUuids().forEach(shapeUuid -> {
+                if (shapes.containsKey(shapeUuid)) {
+                    targetClassUris.addAll(shapes.get(shapeUuid).getTargetClasses());
+                }
+            });
+            cache.put(rd.getUuid(), targetClassUris.stream().sorted().toList());
+        });
+    }
+
+    public List<String> getByUuid(String uuid) {
+        return cache().get(uuid, List.class);
+    }
+
+    private Cache cache() {
+        return cacheManager.getCache(RESOURCE_DEFINITION_TARGET_CLASSES_CACHE);
+    }
+
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeMapper.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeMapper.java
@@ -39,7 +39,9 @@ public class ShapeMapper {
                         shape.getName(),
                         shape.isPublished(),
                         shape.getType(),
-                        shape.getDefinition());
+                        shape.getDefinition(),
+                        shape.getTargetClasses().stream().sorted().toList()
+                );
     }
 
     public Shape fromChangeDTO(ShapeChangeDTO dto, String uuid) {
@@ -50,7 +52,9 @@ public class ShapeMapper {
                         dto.getName(),
                         dto.isPublished(),
                         ShapeType.CUSTOM,
-                        dto.getDefinition());
+                        dto.getDefinition(),
+                        ShapeShaclUtils.extractTargetClasses(dto.getDefinition())
+                );
 
     }
 
@@ -61,6 +65,7 @@ public class ShapeMapper {
                         .name(dto.getName())
                         .published(dto.isPublished())
                         .definition(dto.getDefinition())
+                        .targetClasses(ShapeShaclUtils.extractTargetClasses(dto.getDefinition()))
                         .build();
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeService.java
@@ -25,11 +25,14 @@ package nl.dtls.fairdatapoint.service.shape;
 import nl.dtls.fairdatapoint.api.dto.shape.ShapeChangeDTO;
 import nl.dtls.fairdatapoint.api.dto.shape.ShapeDTO;
 import nl.dtls.fairdatapoint.api.dto.shape.ShapeRemoteDTO;
+import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionRepository;
 import nl.dtls.fairdatapoint.database.mongo.repository.ShapeRepository;
 import nl.dtls.fairdatapoint.entity.exception.ShapeImportException;
 import nl.dtls.fairdatapoint.entity.exception.ValidationException;
+import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import nl.dtls.fairdatapoint.entity.shape.Shape;
 import nl.dtls.fairdatapoint.entity.shape.ShapeType;
+import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionTargetClassesCache;
 import nl.dtls.fairdatapoint.util.RdfIOUtil;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
@@ -43,6 +46,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
@@ -54,10 +58,16 @@ public class ShapeService {
     private ShapeRepository shapeRepository;
 
     @Autowired
+    private ResourceDefinitionRepository resourceDefinitionRepository;
+
+    @Autowired
     private ShapeMapper shapeMapper;
 
     @Autowired
     private ShapeValidator shapeValidator;
+
+    @Autowired
+    private ResourceDefinitionTargetClassesCache targetClassesCache;
 
     public List<ShapeDTO> getShapes() {
         List<Shape> shapes = shapeRepository.findAll();
@@ -97,6 +107,7 @@ public class ShapeService {
         String uuid = UUID.randomUUID().toString();
         Shape shape = shapeMapper.fromChangeDTO(reqDto, uuid);
         shapeRepository.save(shape);
+        targetClassesCache.computeCache();
         return shapeMapper.toDTO(shape);
     }
 
@@ -110,6 +121,7 @@ public class ShapeService {
         Shape shape = oShape.get();
         Shape updatedShape = shapeMapper.fromChangeDTO(reqDto, shape);
         shapeRepository.save(updatedShape);
+        targetClassesCache.computeCache();
         return of(shapeMapper.toDTO(updatedShape));
     }
 
@@ -120,10 +132,17 @@ public class ShapeService {
             return false;
         }
         Shape shape = oShape.get();
+
+        List<ResourceDefinition> resourceDefinitions = resourceDefinitionRepository.findByShapeUuidsIsContaining(shape.getUuid());
+        if (!resourceDefinitions.isEmpty()) {
+            throw new ValidationException(format("Shape is used in %d resource definitions", resourceDefinitions.size()));
+        }
+
         if (shape.getType() == ShapeType.INTERNAL) {
             throw new ValidationException("You can't delete INTERNAL Shape");
         }
         shapeRepository.delete(shape);
+        targetClassesCache.computeCache();
         return true;
     }
 
@@ -144,12 +163,22 @@ public class ShapeService {
                 .collect(Collectors.toList());
     }
 
+    private ShapeDTO importShape(ShapeChangeDTO reqDto) {
+        shapeValidator.validate(reqDto);
+        String uuid = UUID.randomUUID().toString();
+        Shape shape = shapeMapper.fromChangeDTO(reqDto, uuid);
+        shapeRepository.save(shape);
+        return shapeMapper.toDTO(shape);
+    }
+
     public List<ShapeDTO> importShapes(List<ShapeRemoteDTO> reqDtos) {
-        return
+        List<ShapeDTO> result =
                 reqDtos
                         .stream()
                         .map(s -> shapeMapper.fromRemoteDTO(s))
-                        .map(this::createShape)
+                        .map(this::importShape)
                         .collect(Collectors.toList());
+        targetClassesCache.computeCache();
+        return result;
     }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeShaclUtils.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/shape/ShapeShaclUtils.java
@@ -20,27 +20,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package nl.dtls.fairdatapoint.api.dto.config;
+package nl.dtls.fairdatapoint.service.shape;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import nl.dtls.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
-import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
+import nl.dtls.fairdatapoint.util.RdfIOUtil;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
 
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@Setter
-public class BootstrapConfigDTO {
+public class ShapeShaclUtils {
 
-    protected String persistentUrl;
-
-    protected List<ResourceDefinitionDTO> resourceDefinitions;
-
-    protected boolean index;
-
+    public static Set<String> extractTargetClasses(String definition) {
+        return RdfIOUtil
+                .read(definition, "")
+                .filter(null, SHACL.TARGET_CLASS, null)
+                .objects()
+                .stream()
+                .map(Value::stringValue)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Detail_DELETE.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Detail_DELETE.java
@@ -25,6 +25,7 @@ package nl.dtls.fairdatapoint.acceptance.shape;
 import nl.dtls.fairdatapoint.WebIntegrationTest;
 import nl.dtls.fairdatapoint.api.dto.error.ErrorDTO;
 import nl.dtls.fairdatapoint.database.mongo.migration.development.shape.data.ShapeFixtures;
+import nl.dtls.fairdatapoint.database.mongo.repository.ShapeRepository;
 import nl.dtls.fairdatapoint.entity.shape.Shape;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,11 +55,15 @@ public class Detail_DELETE extends WebIntegrationTest {
     @Autowired
     private ShapeFixtures shapeFixtures;
 
+    @Autowired
+    private ShapeRepository shapeRepository;
+
     @Test
     @DisplayName("HTTP 204")
     public void res204() {
         // GIVEN:
-        Shape shape = shapeFixtures.datasetShape();
+        Shape shape = shapeFixtures.customShape();
+        shapeRepository.save(shape);
         RequestEntity<Void> request = RequestEntity
                 .delete(url(shape.getUuid()))
                 .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
@@ -74,8 +79,27 @@ public class Detail_DELETE extends WebIntegrationTest {
     }
 
     @Test
+    @DisplayName("HTTP 400")
+    public void res400_used() {
+        // GIVEN:
+        Shape shape = shapeFixtures.datasetShape();
+        RequestEntity<Void> request = RequestEntity
+                .delete(url(shape.getUuid()))
+                .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                .build();
+        ParameterizedTypeReference<Void> responseType = new ParameterizedTypeReference<>() {
+        };
+
+        // WHEN:
+        ResponseEntity<Void> result = client.exchange(request, responseType);
+
+        // THEN:
+        assertThat(result.getStatusCode(), is(equalTo(HttpStatus.BAD_REQUEST)));
+    }
+
+    @Test
     @DisplayName("HTTP 400: Delete INTERNAL shape")
-    public void res400() {
+    public void res400_internal() {
         // GIVEN:
         Shape shape = shapeFixtures.repositoryShape();
         RequestEntity<Void> request = RequestEntity

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Public_GET.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/shape/Public_GET.java
@@ -38,6 +38,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -68,6 +69,7 @@ public class Public_GET extends WebIntegrationTest {
                 .name(shapeFixtures.customShape().getName())
                 .definition(shapeFixtures.customShape().getDefinition())
                 .published(published)
+                .targetClasses(Set.of())
                 .build();
     }
 

--- a/src/test/java/nl/dtls/fairdatapoint/service/index/harvester/HarvesterServiceTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/index/harvester/HarvesterServiceTest.java
@@ -29,6 +29,7 @@ import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositor
 import nl.dtls.fairdatapoint.database.rdf.repository.generic.GenericMetadataRepository;
 import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import nl.dtls.fairdatapoint.service.metadata.enhance.MetadataEnhancer;
+import nl.dtls.fairdatapoint.service.profile.ProfileService;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionCache;
 import nl.dtls.fairdatapoint.vocabulary.R3D;
 import org.eclipse.rdf4j.model.Model;
@@ -84,8 +85,6 @@ public class HarvesterServiceTest {
     private void setup() {
         // Setup resource definition;
         ResourceDefinitionFixtures resourceDefinitionFixtures = new ResourceDefinitionFixtures();
-        when(resourceDefinitionCache.getByUuid(resourceDefinitionFixtures.catalogDefinition().getUuid()))
-                .thenReturn(resourceDefinitionFixtures.catalogDefinition());
 
         // Setup RDF fixtures
         RdfMetadataFixtures fixtures = new RdfMetadataFixtures(new MetadataFactoryImpl());
@@ -97,9 +96,6 @@ public class HarvesterServiceTest {
         // Create catalog
         catalog = fixtures.catalog1(repositoryUrl, getUri(repository));
         repository.add(i(repositoryUrl), R3D.DATACATALOG, i(catalogUrl));
-
-        // Enhance repository with links
-        metadataEnhancer.enhanceWithLinks(i(repositoryUrl), repository, rdRepository, repositoryUrl, repository);
     }
 
     @Test


### PR DESCRIPTION
- [x] Add relation to shapes in resource definition
- [x] Create profiles based on resource definition
- [x] Add `dct:conformsTo` with profile URI
- [x] Remove target classes from resource definition
- [x] Database migration
- [x] Tests

Not sure if we can easily remove target classes from resource definitions. It is used in many places, e.g., we use it for metadata to set `rdf:type`. This duplicates the information from shape, but in shape is it encoded only in RDF. What would be the best solution @kburger? Do we want to keep target classes for resource definitions or should it be always figured out from linked shapes?