### PR TITLE
[FDP-577] Fix multiple children with the same child relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Reset to defaults works with settings as well
+- Metadata endpoint `**/expanded` is marked as *Deprecated*
+
+### Fixed
+
+- Multiple children resource definitions with the same child relation
 
 ## [1.11.0]
 

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/metadata/GenericController.java
@@ -103,7 +103,7 @@ public class GenericController {
         return shapeService.getShaclFromShapes();
     }
 
-    @Operation(hidden = true)
+    @Operation(hidden = true, deprecated = true)
     @GetMapping(path = "**/expanded", produces = {"!application/json"})
     public Model getMetaDataExpanded(HttpServletRequest request) throws MetadataServiceException {
         // 1. Init
@@ -321,6 +321,7 @@ public class GenericController {
                 // 4.2 Get all children sorted
                 var children = getObjectsBy(entity, entityUri, relationUri)
                         .stream()
+                        .filter((childUri) -> getResourceNameForChild(childUri.toString()).equals(childPrefix))
                         .filter((childUri) -> {
                             if (oCurrentUser.isPresent()) return true;
                             Metadata childState = metadataStateService.get(i(childUri.stringValue()));

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/metadata/MetaDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/metadata/MetaDTO.java
@@ -22,12 +22,16 @@
  */
 package nl.dtls.fairdatapoint.api.dto.metadata;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import nl.dtls.fairdatapoint.api.dto.member.MemberDTO;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
 
 @Schema(name = "MetaDTO")
 @NoArgsConstructor
@@ -36,8 +40,12 @@ import nl.dtls.fairdatapoint.api.dto.member.MemberDTO;
 @Setter
 public class MetaDTO {
 
+    @JsonInclude
     private MemberDTO member;
 
+    @JsonInclude
     private MetaStateDTO state;
 
+    @NotNull
+    private Map<String, MetaPathDTO> path;
 }

--- a/src/main/java/nl/dtls/fairdatapoint/api/dto/metadata/MetaPathDTO.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/dto/metadata/MetaPathDTO.java
@@ -1,0 +1,23 @@
+package nl.dtls.fairdatapoint.api.dto.metadata;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+public class MetaPathDTO {
+
+    @NotNull
+    private String resourceDefinitionUuid;
+
+    @NotNull
+    private String title;
+
+    @JsonInclude
+    private String parent = null;
+}


### PR DESCRIPTION
This fixes the incorrect child links that appeared in pagination result. It also adds ancestors path to `**/meta` which makes `**/expanded` no longer needed.

Closes #156 