### PR TITLE
Refactor wildcard paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Profile resources contain `rdfs:label` with Shape name
 
+### Changed
+
+- Replaced `**` wildcards with safer pattern
+- Added restriction to URL prefixes of Resource Definitions (`[a-zA-Z_-]*`)
+
 ## [1.12.0]
 
 ### Added

--- a/src/main/java/nl/dtls/fairdatapoint/service/metadata/factory/MetadataServiceFactory.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/metadata/factory/MetadataServiceFactory.java
@@ -27,6 +27,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class MetadataServiceFactory {
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionValidator.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/resource/ResourceDefinitionValidator.java
@@ -56,6 +56,11 @@ public class ResourceDefinitionValidator {
             uniquenessValidationFailed("urlPrefix", reqDto);
         }
 
+        // Check urlPrefix validity
+        if (!isValidPrefixUrl(reqDto.getUrlPrefix())) {
+            throw new ValidationException("URL prefix is not valid");
+        }
+
         // Check existence of connected entities
         for (ResourceDefinitionChild child : reqDto.getChildren()) {
             if (resourceDefinitionCache.getByUuid(child.getResourceDefinitionUuid()) == null) {
@@ -80,6 +85,10 @@ public class ResourceDefinitionValidator {
             }
             validateDependencyCycles(reqDto, rdChild.getChildren());
         }
+    }
+
+    private boolean isValidPrefixUrl(String urlPrefix) {
+        return urlPrefix.matches("[a-zA-Z0-9-_]*");
     }
 
 }

--- a/src/main/java/nl/dtls/fairdatapoint/util/HttpUtil.java
+++ b/src/main/java/nl/dtls/fairdatapoint/util/HttpUtil.java
@@ -31,8 +31,10 @@ import org.springframework.http.HttpHeaders;
 import javax.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static nl.dtls.fairdatapoint.util.ValueFactoryHelper.i;
@@ -83,6 +85,27 @@ public class HttpUtil {
         } catch (MalformedURLException e) {
             throw new ValidationException("URL was not in the right format");
         }
+    }
+
+    public static URL getMetadataURL(String persistentUrl, String urlPrefix, String recordId) {
+        try {
+            if (urlPrefix.isEmpty()) {
+                return new URL(persistentUrl);
+            }
+            if (recordId.isEmpty()) {
+                throw new ValidationException("No metadata record identifier given");
+            }
+            return new URL(format("%s/%s/%s", persistentUrl, urlPrefix, recordId));
+        } catch (MalformedURLException e) {
+            throw new ValidationException("URL was not in the right format");
+        }
+    }
+
+    public static IRI getMetadataIRI(String persistentUrl, String urlPrefix, String recordId) {
+        return i(getMetadataURL(persistentUrl, urlPrefix, recordId).toString());
+    }
+    public static IRI generateNewMetadataIRI(String persistentUrl, String urlPrefix) {
+        return getMetadataIRI(persistentUrl, urlPrefix, UUID.randomUUID().toString());
     }
 
     public static IRI generateNewIRI(HttpServletRequest request, String persistentUrl) {

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/metadata/repository/Detail_POST.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/metadata/repository/Detail_POST.java
@@ -37,20 +37,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@DisplayName("DELETE /")
-public class Detail_DELETE extends WebIntegrationTest {
+@DisplayName("POST /")
+public class Detail_POST extends WebIntegrationTest {
 
     private URI url() {
         return URI.create("/");
     }
 
     @Test
-    @DisplayName("HTTP 405")
-    public void res405() {
-        // Repository metadata exist but cannot be deleted (only updated and retrieved)
+    @DisplayName("HTTP 415")
+    public void res415() {
+        // POST / is used for pinging that expects JSON data
         // GIVEN:
         RequestEntity<Void> request = RequestEntity
-                .delete(url())
+                .post(url())
                 .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
                 .header(HttpHeaders.CONTENT_TYPE, "text/turtle")
                 .header(HttpHeaders.ACCEPT, "text/turtle")
@@ -62,7 +62,7 @@ public class Detail_DELETE extends WebIntegrationTest {
         ResponseEntity<Void> result = client.exchange(request, responseType);
 
         // THEN:
-        assertThat(result.getStatusCode(), is(equalTo(HttpStatus.METHOD_NOT_ALLOWED)));
+        assertThat(result.getStatusCode(), is(equalTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE)));
     }
 
 }

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/resource/Detail_PUT.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/resource/Detail_PUT.java
@@ -56,7 +56,7 @@ public class Detail_PUT extends WebIntegrationTest {
 
     private ResourceDefinitionChangeDTO reqDto(ResourceDefinition rd) {
         rd.setName(format("EDITED: %s", rd.getName()));
-        rd.setUrlPrefix(format("%s-edited", rd.getName()));
+        rd.setUrlPrefix(format("%s-edited", rd.getUrlPrefix()));
         return resourceDefinitionMapper.toChangeDTO(rd);
     }
 


### PR DESCRIPTION
This is still WIP (as I won't be able to work on this during few upcoming days). It should also use `recordId` from path to compose metadata URI instead of parsing and replacing URI from `HttpServletRequest`. The pattern with `[^.]+` is used to avoid conflicts with routes that have `.` in name, e.g. `/swagger-ui.html` and `/swagger-ui/index.html`.

However, there are some questions (@kburger):
- Is there any limitation with this approach that I overlooked?
- Can we set a rule for resource definition URL prefix to be composed only using `[a-z0-9-_~]+` (and empty for repository)?
- Should the regex be more permissive (e.g. forbid only `.html` suffix)?
- Any other thoughts?


(I also tested this with the newest SpringDoc OpenAPI-UI and it works, even without hacking `WebMvcConfigurer`.