### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       PRIVATE_REGISTRY_URL: ${{ secrets.PRIVATE_REGISTRY_URL }}
       TAG_DEVELOP: develop
       TAG_LATEST: latest
-      JDK_VERSION: 16
-      JDK_FILE: openjdk-16.0.1_linux-x64_bin.tar.gz
-      JDK_URL: https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz
+      JDK_VERSION: 17
+      JDK_FILE: openjdk-17_linux-x64_bin.tar.gz
+      JDK_URL: https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz
 
     services:
       mongo:
@@ -58,10 +58,12 @@ jobs:
         cp ~/jdk/$JDK_FILE .
 
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2.3.0
       with:
+        distribution: 'jdkfile'
         java-version: ${{ env.JDK_VERSION }}
         jdkFile: ${{ env.JDK_FILE }}
+        architecture: x64
 
     - name: Verify Maven and Java
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ### Added
 
 - Profile resources contain `rdfs:label` with Shape name
@@ -15,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Replaced `**` wildcards with safer pattern
 - Added restriction to URL prefixes of Resource Definitions (`[a-zA-Z_-]*`)
+- Upgrade Java JDK from 16 to 17
 
 ## [1.12.0]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 #
 
-FROM openjdk:16-jdk-slim
+FROM openjdk:17-jdk-slim
 
 WORKDIR /fdp
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -22,7 +22,7 @@
 #
 ################################################################################
 # BUILD STAGE
-FROM maven:3-openjdk-16 as builder
+FROM maven:3-openjdk-17-slim as builder
 
 WORKDIR /builder
 
@@ -32,7 +32,7 @@ RUN mvn --quiet -B -U --fail-fast -DskipTests package
 
 ################################################################################
 # RUN STAGE
-FROM openjdk:16-jdk-slim
+FROM openjdk:17-jdk-slim
 
 WORKDIR /fdp
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ e.g. [app.fairdatapoint.org/swagger-ui.html](https://app.fairdatapoint.org/swagg
 
 ### Technology Stack
 
-- **Java** (JDK 16)
+- **Java** (JDK 17)
 - **MongoDB** (4.2)
 - **Maven** (3.2.5 or higher)
-- **Docker** (17.09.0-ce or higher) - *for building Docker image only*
+- **Docker** (19.03.0-ce or higher) - *for building Docker image only*
 
 ### Build & Run
 
@@ -114,8 +114,7 @@ documentation.
 ## Contributing
 
 We maintain a [CHANGELOG](CHANGELOG.md), you should also take a look at our [Contributing guidelines](CONTRIBUTING.md)
-and
-[Code of Conduct](CODE_OF_CONDUCT.md).
+and [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Maven -->
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <!-- Project related -->
         <spring.rdf.migration.version>1.1.0.RELEASE</spring.rdf.migration.version>


### PR DESCRIPTION
Finally LTS is here and should be supported until 2029. Updates for Java 16 end this month... ([wiki](https://en.wikipedia.org/wiki/Java_version_history))