### PR TITLE
Update log4j dependency to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jwt.version>0.11.2</jwt.version>
         <lombok.version>1.18.22</lombok.version>
         <rdf-resolver.version>0.1.2-SNAPSHOT</rdf-resolver.version>
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
 
         <!-- Plugins -->
         <plugin.license.version>4.1</plugin.license.version>


### PR DESCRIPTION
Update log4j (again) to fix the vulnerability found in 2.15.0 (https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0)