### PR TITLE
CVE-2021-44832 - Bump log4j to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jwt.version>0.11.2</jwt.version>
         <lombok.version>1.18.22</lombok.version>
         <rdf-resolver.version>0.1.2-SNAPSHOT</rdf-resolver.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
 
         <!-- Plugins -->
         <plugin.license.version>4.1</plugin.license.version>


### PR DESCRIPTION
Due to CVE-2021-44832 Apache recommends to update to 2.17.1:
https://logging.apache.org/log4j/2.x/