### PR TITLE
Update to Mongock 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,7 @@
 
         <!-- Core -->
         <springdoc.version>1.6.3</springdoc.version>
-        <mongock.version>4.3.8</mongock.version>
-        <mongodb.driver-sync.version>4.2.3</mongodb.driver-sync.version>
+        <mongock.version>5.0.34</mongock.version>
         <mongodb.spring-data.v3.version>3.3.0</mongodb.spring-data.v3.version>
         <rdf4j.version>3.7.4</rdf4j.version>
         <unirest.version>1.4.9</unirest.version>
@@ -105,7 +104,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.github.cloudyrock.mongock</groupId>
+                <groupId>io.mongock</groupId>
                 <artifactId>mongock-bom</artifactId>
                 <version>${mongock.version}</version>
                 <type>pom</type>
@@ -180,17 +179,12 @@
         <!--   Mongock          -->
         <!-- ////////////////// -->
         <dependency>
-            <groupId>com.github.cloudyrock.mongock</groupId>
-            <artifactId>mongock-spring-v5</artifactId>
+            <groupId>io.mongock</groupId>
+            <artifactId>mongock-springboot</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.cloudyrock.mongock</groupId>
+            <groupId>io.mongock</groupId>
             <artifactId>mongodb-springdata-v3-driver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
-            <version>${mongodb.driver-sync.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/src/main/java/nl/dtls/fairdatapoint/config/MongoConfig.java
+++ b/src/main/java/nl/dtls/fairdatapoint/config/MongoConfig.java
@@ -22,9 +22,10 @@
  */
 package nl.dtls.fairdatapoint.config;
 
-import com.github.cloudyrock.mongock.config.LegacyMigration;
-import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
-import com.github.cloudyrock.spring.v5.MongockSpring5;
+import io.mongock.api.config.LegacyMigration;
+import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
+import io.mongock.runner.springboot.MongockSpringboot;
+import io.mongock.runner.springboot.base.MongockInitializingBeanRunner;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionCache;
 import nl.dtls.fairdatapoint.service.resource.ResourceDefinitionTargetClassesCache;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,16 +48,16 @@ public class MongoConfig {
     private ResourceDefinitionTargetClassesCache targetClassesCache;
 
     @Bean("mongockRunner")
-    public MongockSpring5.MongockApplicationRunner mongockApplicationRunner(
+    public MongockInitializingBeanRunner mongockApplicationRunner(
             ApplicationContext springContext,
             MongoTemplate mongoTemplate) {
-        return MongockSpring5.builder()
+        return MongockSpringboot.builder()
                 .setDriver(SpringDataMongoV3Driver.withDefaultLock(mongoTemplate))
-                .addChangeLogsScanPackage("nl.dtls.fairdatapoint.database.mongo.migration.production")
+                .addMigrationScanPackage("nl.dtls.fairdatapoint.database.mongo.migration.production")
                 .setSpringContext(springContext)
                 .setLegacyMigration(new LegacyMigration("dbchangelog"))
                 .addDependency(ResourceDefinitionCache.class, resourceDefinitionCache)
                 .addDependency(ResourceDefinitionTargetClassesCache.class, targetClassesCache)
-                .buildApplicationRunner();
+                .buildInitializingBeanRunner();
     }
 }


### PR DESCRIPTION
They also deprecated `@ChangeLog` and `@ChangeSet` annotations, but that must be the same for old migrations... However, new migrations should use `@ChangeUnit`: https://mongock.io/v5/from-version-4-to-5/

Luckily, we don't need the extra `mongo-driver-sync` dependency and it will allow to update `spring-boot` to 2.6+