### PR TITLE
Hotfix 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 
+## [1.13.1]
+
+### Changed
+
+- Upgrade to Spring Boot 2.6.6 due to [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965) ([more info](https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now))
+
 ## [1.13.0]
 
 ### Added
@@ -287,3 +293,4 @@ The first release of reference FAIR Data Point implementation.
 [1.12.3]: /../../tree/v1.12.3
 [1.12.4]: /../../tree/v1.12.4
 [1.13.0]: /../../tree/v1.13.0
+[1.13.1]: /../../tree/v1.13.1

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>nl.dtls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>nl.dtls</groupId>
     <artifactId>fairdatapoint</artifactId>
-    <version>1.13.0</version>
+    <version>1.13.1</version>
     <packaging>jar</packaging>
 
     <name>FairDataPoint</name>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,7 @@ metadataProperties:
 
 openapi:
   title: FAIR Data Point API
-  version: 1.13.0
+  version: 1.13.1
   description: "The reference implementation of the metadata registration service: A service implementing the API specification. It contains an authentication system to allow maintainers to define and update metadata. Read-only access to the data is public."
   contact:
     name: Luiz Bonino


### PR DESCRIPTION
Upgrade to Spring Boot 2.6.6 due to [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965) ([more info](https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now))