### PR TITLE
Get FAIRDataTeam dependencies from Github Packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,8 @@
             <!-- use <id> to specify github PAT in ~/.m2/settings.xml <server> section: https://maven.apache.org/settings.html#servers -->
             <id>github-packages</id>
             <name>Github Packages</name>
-            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url>
+            <!-- TODO: use <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url> -->
+            <url>https://maven.pkg.github.com/dennisvang/*</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,15 @@
             </snapshots>
         </repository>
         <repository>
-            <id>nexus-releases</id>
-            <name>Nexus Releases</name>
-            <url>https://nexus.internal.fairdatapoint.org/repository/maven-releases/</url>
-        </repository>
-        <repository>
-            <id>nexus-snapshots</id>
-            <name>Nexus Snapshots</name>
-            <url>https://nexus.internal.fairdatapoint.org/repository/maven-snapshots/</url>
+            <!-- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry -->
+            <!-- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow -->
+            <!-- use <id> to specify github PAT in ~/.m2/settings.xml <server> section: https://maven.apache.org/settings.html#servers -->
+            <id>github-packages</id>
+            <name>Github Packages</name>
+            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,12 +214,12 @@
             <version>${lombok.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.fairdevkit</groupId>
+            <groupId>com.github.fairdatateam</groupId>
             <artifactId>rdf-resource-resolver-core</artifactId>
             <version>${rdf-resolver.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.fairdevkit</groupId>
+            <groupId>com.github.fairdatateam</groupId>
             <artifactId>rdf-resource-resolver-api</artifactId>
             <version>${rdf-resolver.version}</version>
         </dependency>

--- a/src/main/java/org/fairdatapoint/service/label/LabelService.java
+++ b/src/main/java/org/fairdatapoint/service/label/LabelService.java
@@ -25,10 +25,10 @@ package org.fairdatapoint.service.label;
 import static java.util.function.Predicate.isEqual;
 import static org.fairdatapoint.config.CacheConfig.LABEL_CACHE;
 import static org.fairdatapoint.util.ValueFactoryHelper.i;
-import com.github.fairdevkit.rdf.resolver.api.ResourceResolver;
-import com.github.fairdevkit.rdf.resolver.core.ContentNegotiationStrategy;
-import com.github.fairdevkit.rdf.resolver.core.CoreResourceResolver;
-import com.github.fairdevkit.rdf.resolver.core.PathExtensionStrategy;
+import com.github.fairdatateam.rdf.resolver.api.ResourceResolver;
+import com.github.fairdatateam.rdf.resolver.core.ContentNegotiationStrategy;
+import com.github.fairdatateam.rdf.resolver.core.CoreResourceResolver;
+import com.github.fairdatateam.rdf.resolver.core.PathExtensionStrategy;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
Get FAIRDataTeam dependencies from Github Packages instead of nexus.internal.fairdatapoint.org:

- [FAIRDataTeam/spring-rdf-migration](https://github.com/FAIRDataTeam/spring-rdf-migration)
- [FAIRDataTeam/rdf-resource-resolver](https://github.com/FAIRDataTeam/rdf-resource-resolver)
 
TODOS:

- [ ] use namespace `org.fairdatapoint` for dependencies, instead of `com.github.fairdatateam`? (to match c94b209)
- [ ] use `GITHUB_REPOSITORY_OWNER` in pom.xml (temporarily using `dennisvang` forks of dependencies, until PRs are merged)
- [ ] add settings.xml to github workflow, with username and personal access token (PAT), because installation from github packages requires authentication, *even for public packages*
- [ ] add dev setup instructions for the github authentication (or maybe just use maven central anyway?)

fixes #574 