### PR TITLE
Get FAIR Data Team dependencies from Maven Central repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Project related -->
-        <spring.rdf.migration.version>2.0.0dev0</spring.rdf.migration.version>
-        <rdf-resolver.version>0.2.0dev0</rdf-resolver.version>
+        <spring.rdf.migration.version>2.0.0</spring.rdf.migration.version>
+        <rdf-resolver.version>0.2.0</rdf-resolver.version>
         
         <!-- Core -->
         <springdoc.version>2.5.0</springdoc.version>
@@ -82,17 +82,17 @@
         <!--   Project related  -->
         <!-- ////////////////// -->
         <dependency>
-            <groupId>io.github.dennisvang</groupId>
+            <groupId>org.fairdatateam.rdf</groupId>
             <artifactId>spring-rdf-migration</artifactId>
             <version>${spring.rdf.migration.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.dennisvang</groupId>
+            <groupId>org.fairdatateam.rdf</groupId>
             <artifactId>rdf-resource-resolver-core</artifactId>
             <version>${rdf-resolver.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.dennisvang</groupId>
+            <groupId>org.fairdatateam.rdf</groupId>
             <artifactId>rdf-resource-resolver-api</artifactId>
             <version>${rdf-resolver.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,8 @@
             <!-- use <id> to specify github PAT in ~/.m2/settings.xml <server> section: https://maven.apache.org/settings.html#servers -->
             <id>github-packages</id>
             <name>Github Packages</name>
-            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url>
+            <!-- TODO: use <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url> -->
+            <url>https://maven.pkg.github.com/dennisvang/*</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -51,15 +51,15 @@
         <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Project related -->
-        <spring.rdf.migration.version>1.2.0.RELEASE</spring.rdf.migration.version>
-
+        <spring.rdf.migration.version>2.0.0dev0</spring.rdf.migration.version>
+        <rdf-resolver.version>0.2.0dev0</rdf-resolver.version>
+        
         <!-- Core -->
         <springdoc.version>2.5.0</springdoc.version>
         <postgresql.version>42.7.3</postgresql.version>
         <rdf4j.version>4.3.12</rdf4j.version>
         <jwt.version>0.12.5</jwt.version>
         <lombok.version>1.18.32</lombok.version>
-        <rdf-resolver.version>0.1.2-SNAPSHOT</rdf-resolver.version>
         <hypersistence.version>3.7.6</hypersistence.version>
 
         <!-- Test -->
@@ -76,44 +76,25 @@
         <plugin.spotbugs.version>4.8.5.0</plugin.spotbugs.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-        <repository>
-            <!-- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry -->
-            <!-- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow -->
-            <!-- use <id> to specify github PAT in ~/.m2/settings.xml <server> section: https://maven.apache.org/settings.html#servers -->
-            <id>github-packages</id>
-            <name>Github Packages</name>
-            <!-- TODO: use <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url> -->
-            <url>https://maven.pkg.github.com/dennisvang/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencies>
 
         <!-- ////////////////// -->
         <!--   Project related  -->
         <!-- ////////////////// -->
         <dependency>
-            <groupId>nl.dtls</groupId>
+            <groupId>io.github.dennisvang</groupId>
             <artifactId>spring-rdf-migration</artifactId>
             <version>${spring.rdf.migration.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.dennisvang</groupId>
+            <artifactId>rdf-resource-resolver-core</artifactId>
+            <version>${rdf-resolver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.dennisvang</groupId>
+            <artifactId>rdf-resource-resolver-api</artifactId>
+            <version>${rdf-resolver.version}</version>
         </dependency>
 
         <!-- ////////////////// -->
@@ -213,16 +194,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.fairdatateam</groupId>
-            <artifactId>rdf-resource-resolver-core</artifactId>
-            <version>${rdf-resolver.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.fairdatateam</groupId>
-            <artifactId>rdf-resource-resolver-api</artifactId>
-            <version>${rdf-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,15 @@
             </snapshots>
         </repository>
         <repository>
-            <id>nexus-releases</id>
-            <name>Nexus Releases</name>
-            <url>https://nexus.internal.fairdatapoint.org/repository/maven-releases/</url>
-        </repository>
-        <repository>
-            <id>nexus-snapshots</id>
-            <name>Nexus Snapshots</name>
-            <url>https://nexus.internal.fairdatapoint.org/repository/maven-snapshots/</url>
+            <!-- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry -->
+            <!-- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow -->
+            <!-- use <id> to specify github PAT in ~/.m2/settings.xml <server> section: https://maven.apache.org/settings.html#servers -->
+            <id>github-packages</id>
+            <name>Github Packages</name>
+            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY_OWNER}/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,12 +214,12 @@
             <version>${lombok.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.fairdevkit</groupId>
+            <groupId>com.github.fairdatateam</groupId>
             <artifactId>rdf-resource-resolver-core</artifactId>
             <version>${rdf-resolver.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.fairdevkit</groupId>
+            <groupId>com.github.fairdatateam</groupId>
             <artifactId>rdf-resource-resolver-api</artifactId>
             <version>${rdf-resolver.version}</version>
         </dependency>

--- a/src/main/java/org/fairdatapoint/config/RepositoryMigrationConfig.java
+++ b/src/main/java/org/fairdatapoint/config/RepositoryMigrationConfig.java
@@ -23,8 +23,8 @@
 package org.fairdatapoint.config;
 
 import org.fairdatapoint.Profiles;
-import nl.dtls.rdf.migration.database.RdfMigrationRepository;
-import nl.dtls.rdf.migration.runner.RdfProductionMigrationRunner;
+import org.fairdatateam.rdf.migration.database.RdfMigrationRepository;
+import org.fairdatateam.rdf.migration.runner.RdfProductionMigrationRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0001_Init.java
+++ b/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0001_Init.java
@@ -24,8 +24,8 @@ package org.fairdatapoint.database.rdf.migration.production;
 
 import lombok.extern.slf4j.Slf4j;
 import org.fairdatapoint.service.reset.FactoryDefaults;
-import nl.dtls.rdf.migration.entity.RdfMigrationAnnotation;
-import nl.dtls.rdf.migration.runner.RdfProductionMigration;
+import org.fairdatateam.rdf.migration.entity.RdfMigrationAnnotation;
+import org.fairdatateam.rdf.migration.runner.RdfProductionMigration;
 import org.bson.Document;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;

--- a/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0002_Metadata_Draft.java
+++ b/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0002_Metadata_Draft.java
@@ -23,8 +23,8 @@
 package org.fairdatapoint.database.rdf.migration.production;
 
 import lombok.extern.slf4j.Slf4j;
-import nl.dtls.rdf.migration.entity.RdfMigrationAnnotation;
-import nl.dtls.rdf.migration.runner.RdfProductionMigration;
+import org.fairdatateam.rdf.migration.entity.RdfMigrationAnnotation;
+import org.fairdatateam.rdf.migration.runner.RdfProductionMigration;
 import org.springframework.stereotype.Service;
 
 @RdfMigrationAnnotation(

--- a/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0003_FDPO.java
+++ b/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0003_FDPO.java
@@ -23,8 +23,8 @@
 package org.fairdatapoint.database.rdf.migration.production;
 
 import lombok.extern.slf4j.Slf4j;
-import nl.dtls.rdf.migration.entity.RdfMigrationAnnotation;
-import nl.dtls.rdf.migration.runner.RdfProductionMigration;
+import org.fairdatateam.rdf.migration.entity.RdfMigrationAnnotation;
+import org.fairdatateam.rdf.migration.runner.RdfProductionMigration;
 import org.springframework.stereotype.Service;
 
 @RdfMigrationAnnotation(

--- a/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0004_Cleanup_Index.java
+++ b/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0004_Cleanup_Index.java
@@ -23,8 +23,8 @@
 package org.fairdatapoint.database.rdf.migration.production;
 
 import lombok.extern.slf4j.Slf4j;
-import nl.dtls.rdf.migration.entity.RdfMigrationAnnotation;
-import nl.dtls.rdf.migration.runner.RdfProductionMigration;
+import org.fairdatateam.rdf.migration.entity.RdfMigrationAnnotation;
+import org.fairdatateam.rdf.migration.runner.RdfProductionMigration;
 import org.springframework.stereotype.Service;
 
 @RdfMigrationAnnotation(

--- a/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0005_FixMetadataVersion.java
+++ b/src/main/java/org/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0005_FixMetadataVersion.java
@@ -23,8 +23,8 @@
 package org.fairdatapoint.database.rdf.migration.production;
 
 import lombok.extern.slf4j.Slf4j;
-import nl.dtls.rdf.migration.entity.RdfMigrationAnnotation;
-import nl.dtls.rdf.migration.runner.RdfProductionMigration;
+import org.fairdatateam.rdf.migration.entity.RdfMigrationAnnotation;
+import org.fairdatateam.rdf.migration.runner.RdfProductionMigration;
 import org.springframework.stereotype.Service;
 
 @RdfMigrationAnnotation(

--- a/src/main/java/org/fairdatapoint/service/label/LabelService.java
+++ b/src/main/java/org/fairdatapoint/service/label/LabelService.java
@@ -25,10 +25,10 @@ package org.fairdatapoint.service.label;
 import static java.util.function.Predicate.isEqual;
 import static org.fairdatapoint.config.CacheConfig.LABEL_CACHE;
 import static org.fairdatapoint.util.ValueFactoryHelper.i;
-import com.github.fairdatateam.rdf.resolver.api.ResourceResolver;
-import com.github.fairdatateam.rdf.resolver.core.ContentNegotiationStrategy;
-import com.github.fairdatateam.rdf.resolver.core.CoreResourceResolver;
-import com.github.fairdatateam.rdf.resolver.core.PathExtensionStrategy;
+import org.fairdatateam.rdf.resolver.api.ResourceResolver;
+import org.fairdatateam.rdf.resolver.core.ContentNegotiationStrategy;
+import org.fairdatateam.rdf.resolver.core.CoreResourceResolver;
+import org.fairdatateam.rdf.resolver.core.PathExtensionStrategy;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/fairdatapoint/service/label/LabelService.java
+++ b/src/main/java/org/fairdatapoint/service/label/LabelService.java
@@ -25,10 +25,10 @@ package org.fairdatapoint.service.label;
 import static java.util.function.Predicate.isEqual;
 import static org.fairdatapoint.config.CacheConfig.LABEL_CACHE;
 import static org.fairdatapoint.util.ValueFactoryHelper.i;
-import com.github.fairdevkit.rdf.resolver.api.ResourceResolver;
-import com.github.fairdevkit.rdf.resolver.core.ContentNegotiationStrategy;
-import com.github.fairdevkit.rdf.resolver.core.CoreResourceResolver;
-import com.github.fairdevkit.rdf.resolver.core.PathExtensionStrategy;
+import com.github.fairdatateam.rdf.resolver.api.ResourceResolver;
+import com.github.fairdatateam.rdf.resolver.core.ContentNegotiationStrategy;
+import com.github.fairdatateam.rdf.resolver.core.CoreResourceResolver;
+import com.github.fairdatateam.rdf.resolver.core.PathExtensionStrategy;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,4 +111,3 @@ springdoc:
 
 server:
   forward-headers-strategy: framework
-  port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,3 +111,4 @@ springdoc:
 
 server:
   forward-headers-strategy: framework
+  port: 8080


### PR DESCRIPTION
This PR fixes #574:

- [x] adapt `pom.xml` to obtain dependencies `rdf-resource-resolver` and 
`spring-rdf-migration` from Maven Central repository. 
- [x] adapt corresponding package imports to use new namespace `org.fairdatateam.rdf`

TODO: For this to work, we need to merge PRs for the dependencies and publish corresponding releases:

- [x] https://github.com/FAIRDataTeam/spring-rdf-migration/pull/3
- [x] https://github.com/FAIRDataTeam/rdf-resource-resolver/pull/2



