### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: FDP Documentation
     url: https://fairdatapoint.readthedocs.io/

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,26 +9,26 @@ body:
       value: |
         Please check [previous questions](https://github.com/FAIRDataTeam/FAIRDataPoint/issues?q=is%3Aissue+label%3AFeature%20Request+) first if you cannot already find an answer there.
   - type: textarea
-    id: question
+    id: question-related
     attributes:
       label: Is your feature request related to a problem?
       description: A clear and concise description of what the problem is. Ex. I'm always frustrated when...
     validations:
       required: true
   - type: textarea
-    id: question
+    id: question-solution
     attributes:
       label: What solution you'd like?
       description: A clear and concise description of what you want to happen.
     validations:
       required: true
   - type: textarea
-    id: question
+    id: question-alternatives
     attributes:
       label: What alternatives have you considered?
       description: A clear and concise description of any alternative solutions or features you've considered.
   - type: textarea
-    id: question
+    id: question-context
     attributes:
       label: Additional context
       description: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
- fixes duplicate ids in feature-request template
- enables *blank* issues:
  Although issue *templates* are useful when used properly, I see several drawbacks:
    - increased threshold for reporting issues (reporter's time is valuable!)
    - increased maintenance burden (current PR is template maintenance...)
    - often too restrictive or not a good fit
    - often too verbose
  
  By enabling blank issues, reporter gets to choose.