### PR TITLE
handle invalid sort parameters

### DIFF
--- a/src/main/java/org/fairdatapoint/api/controller/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/org/fairdatapoint/api/controller/exception/ExceptionControllerAdvice.java
@@ -30,6 +30,7 @@ package org.fairdatapoint.api.controller.exception;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.fairdatapoint.api.dto.error.ErrorDTO;
@@ -42,6 +43,7 @@ import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -243,4 +245,9 @@ public class ExceptionControllerAdvice {
         return new ErrorDTO(HttpStatus.BAD_REQUEST, message, details);
     }
 
+    @ResponseStatus(value = HttpStatus.UNPROCESSABLE_ENTITY, reason = "Unknown field")
+    @ExceptionHandler(PropertyReferenceException.class)
+    public void handleUnknownField(HttpServletRequest request) {
+        log.error("Unknown field: {}", request.getRequestURL());
+    }
 }

--- a/src/main/java/org/fairdatapoint/api/dto/index/entry/IndexEntryDTO.java
+++ b/src/main/java/org/fairdatapoint/api/dto/index/entry/IndexEntryDTO.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 import org.fairdatapoint.entity.index.entry.IndexEntryPermit;
 import org.hibernate.validator.constraints.URL;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @NoArgsConstructor
@@ -52,8 +53,8 @@ public class IndexEntryDTO {
     private IndexEntryPermit permit;
 
     @NotNull
-    private String registrationTime;
+    private Instant createdAt;
 
     @NotNull
-    private String modificationTime;
+    private Instant updatedAt;
 }

--- a/src/main/java/org/fairdatapoint/api/dto/index/entry/IndexEntryDetailDTO.java
+++ b/src/main/java/org/fairdatapoint/api/dto/index/entry/IndexEntryDetailDTO.java
@@ -32,6 +32,7 @@ import org.fairdatapoint.entity.index.entry.IndexEntryPermit;
 import org.fairdatapoint.entity.index.entry.RepositoryMetadata;
 import org.hibernate.validator.constraints.URL;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -61,12 +62,12 @@ public class IndexEntryDetailDTO {
     private List<EventDTO> events;
 
     @NotNull
-    private String registrationTime;
+    private Instant createdAt;
 
     @NotNull
-    private String modificationTime;
+    private Instant updatedAt;
 
     @NotNull
-    private String lastRetrievalTime;
+    private Instant lastRetrievalAt;
 
 }

--- a/src/main/java/org/fairdatapoint/service/index/entry/IndexEntryMapper.java
+++ b/src/main/java/org/fairdatapoint/service/index/entry/IndexEntryMapper.java
@@ -50,8 +50,8 @@ public class IndexEntryMapper {
                         indexEntry.getLastRetrievalAt(),
                         validThreshold),
                 indexEntry.getPermit(),
-                indexEntry.getCreatedAt().toString(),
-                indexEntry.getUpdatedAt().toString()
+                indexEntry.getCreatedAt(),
+                indexEntry.getUpdatedAt()
         );
     }
 
@@ -69,18 +69,18 @@ public class IndexEntryMapper {
                 StreamSupport.stream(events.spliterator(), false)
                         .map(eventMapper::toDTO)
                         .toList(),
-                indexEntry.getCreatedAt().toString(),
-                indexEntry.getUpdatedAt().toString(),
-                indexEntry.getLastRetrievalAt().toString()
+                indexEntry.getCreatedAt(),
+                indexEntry.getUpdatedAt(),
+                indexEntry.getLastRetrievalAt()
         );
     }
 
     public IndexEntryStateDTO toStateDTO(
-            IndexEntryState state, Instant lastRetrievalTime, Instant validThreshold
+            IndexEntryState state, Instant lastRetrievalAt, Instant validThreshold
     ) {
         return switch (state) {
             case UNKNOWN -> IndexEntryStateDTO.UNKNOWN;
-            case VALID -> lastRetrievalTime.isAfter(validThreshold)
+            case VALID -> lastRetrievalAt.isAfter(validThreshold)
                     ? IndexEntryStateDTO.ACTIVE
                     : IndexEntryStateDTO.INACTIVE;
             case INVALID -> IndexEntryStateDTO.INVALID;

--- a/src/test/java/org/fairdatapoint/acceptance/index/entry/List_GET.java
+++ b/src/test/java/org/fairdatapoint/acceptance/index/entry/List_GET.java
@@ -31,6 +31,8 @@ import org.fairdatapoint.utils.CustomPageImpl;
 import org.fairdatapoint.utils.TestIndexEntryFixtures;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
@@ -74,6 +76,12 @@ public class List_GET extends WebIntegrationTest {
     private URI urlWithPermit(String permitQuery) {
         return UriComponentsBuilder.fromUri(url())
                 .queryParam("permit", permitQuery)
+                .build().toUri();
+    }
+
+    private URI urlWithSorting(String sortQuery) {
+        return UriComponentsBuilder.fromUri(url())
+                .queryParam("sort", sortQuery)
                 .build().toUri();
     }
 
@@ -161,6 +169,39 @@ public class List_GET extends WebIntegrationTest {
             assertThat("Entry matches: " + entries.get(i).getClientUrl(),
                     result.getBody().getContent().get(i).getClientUrl(), is(equalTo(entries.get(i).getClientUrl())));
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'updatedAt,desc', OK",
+            "'modificationTime,desc', UNPROCESSABLE_ENTITY"
+    })
+    @DisplayName("HTTP 200: page few (sorted)")
+    public void res200_pageFewSorted(String sortQuery, String expectedStatus) {
+        // Test for issue #633
+        //
+        // https://www.rfc-editor.org/rfc/rfc9110.html
+        //
+        // todo: The res200_ naming convention is a bit restrictive and does not cover
+        //  multiple cases. Should we rename to regression tests or something?
+
+        // GIVEN: prepare data
+        indexEntryRepository.deleteAll();
+        List<IndexEntry> entries = TestIndexEntryFixtures.entriesFew();
+        indexEntryRepository.saveAll(entries);
+
+        // AND: prepare request
+        RequestEntity<?> request = RequestEntity
+                .get(urlWithSorting(sortQuery))
+                .accept(MediaType.APPLICATION_JSON)
+                .build();
+
+        // WHEN
+        ResponseEntity<CustomPageImpl<IndexEntryDTO>> result = client.exchange(request, responseType);
+
+        // THEN
+        assertThat("Correct response code is received",
+                result.getStatusCode(), is(equalTo(HttpStatus.valueOf(expectedStatus))));
     }
 
     @Test

--- a/src/test/java/org/fairdatapoint/acceptance/index/entry/List_GET.java
+++ b/src/test/java/org/fairdatapoint/acceptance/index/entry/List_GET.java
@@ -173,8 +173,8 @@ public class List_GET extends WebIntegrationTest {
 
     @ParameterizedTest
     @CsvSource({
-            "'updatedAt,desc', OK",
-            "'modificationTime,desc', UNPROCESSABLE_ENTITY"
+            "'updatedAt,desc', OK",  // existing field
+            "'modificationTime,desc', UNPROCESSABLE_ENTITY"  // non-existent field
     })
     @DisplayName("HTTP 200: page few (sorted)")
     public void res200_pageFewSorted(String sortQuery, String expectedStatus) {


### PR DESCRIPTION
- Added a test to reproduce #633
- Added a rudimentary exception handler for `PropertyReferenceException`, returning a status `422` "Unprocessable"
- Replaced last occurrences of `registrationTime`, `modificationTime`, and `lastRetrievalTime`, by `createdAt`, `updatedAt`, and `lastRetrievalAt`, respectively