### PR TITLE
Ignore case when sorting resources by title

### DIFF
--- a/src/main/java/org/fairdatapoint/api/controller/metadata/GenericController.java
+++ b/src/main/java/org/fairdatapoint/api/controller/metadata/GenericController.java
@@ -352,7 +352,7 @@ public class GenericController {
                             if (title2 == null) {
                                 return 1;
                             }
-                            return title1.compareTo(title2);
+                            return title1.compareToIgnoreCase(title2);
                         })
                         .toList();
 


### PR DESCRIPTION
Using `compareToIgnoreCase()` instead of `compareTo()`.

Note: maybe a good idea also to check the other uses of `compareTo` in the codebase...

fixes #676