### PR TITLE
Upgrade dependencies for v1.17.x

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       JAVA_DISTRIBUTION: temurin
-      JAVA_VERSION: 17
+      JAVA_VERSION: 21
 
     steps:
       - name: Checkout repository
@@ -45,7 +45,7 @@ jobs:
 
     env:
       JAVA_DISTRIBUTION: temurin
-      JAVA_VERSION: 17
+      JAVA_VERSION: 21
 
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
 
     env:
       JAVA_DISTRIBUTION: temurin
-      JAVA_VERSION: 17
+      JAVA_VERSION: 21
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
   verify:
     uses: FAIRDataTeam/github-workflows/.github/workflows/maven-verify.yml@v2
     with:
-      java-version: 17
+      java-version: 21
       # todo: enable tests when test duration has been minimized
       mvn-options: "-DskipTests"
   publish:

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-14
             mongo: 8
         java-version:
-          - 17
+          - 21
     uses: FAIRDataTeam/github-workflows/.github/workflows/maven-verify.yml@v2
     with:
       runner: ${{ matrix.runner.os }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
 
     env:
       JAVA_DISTRIBUTION: temurin
-      JAVA_VERSION: 17
+      JAVA_VERSION: 21
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Cleaned up Dockerfile (backport)
 - Separate Github workflows for test and publish (backport)
+- Upgraded to Java JDK 21 (LTS)
+- Upgraded to latest dependencies
 
 ## [1.17.2]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 # BUILD JAR
 
-FROM maven:3-eclipse-temurin-17-focal AS builder
+FROM maven:3-eclipse-temurin-21-alpine AS builder
 
 WORKDIR /builder
 
@@ -16,12 +16,11 @@ RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests package
 ################################################################################
 # BUILD IMAGE
 
-FROM eclipse-temurin:17-jdk-focal
+FROM eclipse-temurin:21-jdk-alpine
 
 # add non-root user to run the app
 # https://spring.io/guides/gs/spring-boot-docker
-# on ubuntu the following creates a group with the same name as user
-RUN adduser spring --system --group
+RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 
 WORKDIR /fdp

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ e.g. [app.fairdatapoint.org/swagger-ui.html](https://app.fairdatapoint.org/swagg
 
 ### Technology Stack
 
-- **Java** (JDK 17)
+- **Java** (JDK 21)
 - **MongoDB** (4.2)
 - **Maven** (3.2.5 or higher)
 - **Docker** (19.03.0-ce or higher) - *for building Docker image only*

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <!-- Core -->
         <springdoc.version>2.8.8</springdoc.version>
         <mongock.version>5.5.1</mongock.version>
-        <mongodb.spring-data.version>4.1.1</mongodb.spring-data.version>
         <rdf4j.version>5.1.3</rdf4j.version>
         <jwt.version>0.12.6</jwt.version>
         <lombok.version>1.18.38</lombok.version>
@@ -175,7 +174,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>${mongodb.spring-data.version}</version>
         </dependency>
 
         <!-- ////////////////// -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>nl.dtls</groupId>
@@ -56,25 +56,25 @@
         <spring.security.acl.mongodb.version>6.0.0</spring.security.acl.mongodb.version>
 
         <!-- Core -->
-        <springdoc.version>2.1.0</springdoc.version>
+        <springdoc.version>2.8.6</springdoc.version>
         <mongock.version>5.3.1</mongock.version>
         <mongodb.spring-data.version>4.1.1</mongodb.spring-data.version>
-        <rdf4j.version>4.3.2</rdf4j.version>
-        <jwt.version>0.11.5</jwt.version>
-        <lombok.version>1.18.28</lombok.version>
+        <rdf4j.version>5.1.3</rdf4j.version>
+        <jwt.version>0.12.6</jwt.version>
+        <lombok.version>1.18.38</lombok.version>
 
         <!-- Test -->
-        <httpclient5.version>5.2.1</httpclient5.version>
+        <httpclient5.version>5.4.4</httpclient5.version>
 
         <!-- Plugins -->
-        <plugin.license.version>4.2</plugin.license.version>
+        <plugin.license.version>5.0.0</plugin.license.version>
         <plugin.jacoco.version>0.7.6.201602180812</plugin.jacoco.version>
         <plugin.coveralls.version>4.3.0</plugin.coveralls.version>
         <plugin.javax_xml_bind.version>2.3.1</plugin.javax_xml_bind.version>
-        <plugin.git_commit_id.version>6.0.0</plugin.git_commit_id.version>
+        <plugin.git_commit_id.version>9.0.1</plugin.git_commit_id.version>
         <plugin.rdf4j_generator.version>0.2.0</plugin.rdf4j_generator.version>
-        <plugin.checkstyle.version>3.3.0</plugin.checkstyle.version>
-        <plugin.spotbugs.version>4.7.3.5</plugin.spotbugs.version>
+        <plugin.checkstyle.version>3.6.0</plugin.checkstyle.version>
+        <plugin.spotbugs.version>4.9.3.0</plugin.spotbugs.version>
     </properties>
 
     <dependencyManagement>
@@ -347,12 +347,12 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.12.1</version>
+                        <version>10.23.1</version>
                     </dependency>
                     <dependency>
                         <groupId>io.spring.javaformat</groupId>
                         <artifactId>spring-javaformat-checkstyle</artifactId>
-                        <version>0.0.39</version>
+                        <version>0.0.43</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <spring.security.acl.mongodb.version>6.0.0</spring.security.acl.mongodb.version>
 
         <!-- Core -->
-        <springdoc.version>2.8.6</springdoc.version>
+        <springdoc.version>2.8.8</springdoc.version>
         <mongock.version>5.3.1</mongock.version>
         <mongodb.spring-data.version>4.1.1</mongodb.spring-data.version>
         <rdf4j.version>5.1.3</rdf4j.version>
@@ -352,7 +352,7 @@
                     <dependency>
                         <groupId>io.spring.javaformat</groupId>
                         <artifactId>spring-javaformat-checkstyle</artifactId>
-                        <version>0.0.43</version>
+                        <version>0.0.44</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <mongock.version>5.5.1</mongock.version>
         <rdf4j.version>5.1.3</rdf4j.version>
         <jwt.version>0.12.6</jwt.version>
-        <lombok.version>1.18.38</lombok.version>
 
         <!-- Test -->
         <httpclient5.version>5.4.4</httpclient5.version>
@@ -226,7 +225,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
         </dependency>
 
         <!-- ////////////////// -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
         <!-- Core -->
         <springdoc.version>2.8.8</springdoc.version>
-        <mongock.version>5.3.1</mongock.version>
+        <mongock.version>5.5.1</mongock.version>
         <mongodb.spring-data.version>4.1.1</mongodb.spring-data.version>
         <rdf4j.version>5.1.3</rdf4j.version>
         <jwt.version>0.12.6</jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.5.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>nl.dtls</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <jwt.version>0.12.6</jwt.version>
 
         <!-- Test -->
-        <httpclient5.version>5.4.4</httpclient5.version>
+        <httpclient5.version>5.5</httpclient5.version>
 
         <!-- Plugins -->
         <plugin.license.version>5.0.0</plugin.license.version>
@@ -343,12 +343,12 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.23.1</version>
+                        <version>10.24.0</version>
                     </dependency>
                     <dependency>
                         <groupId>io.spring.javaformat</groupId>
                         <artifactId>spring-javaformat-checkstyle</artifactId>
-                        <version>0.0.44</version>
+                        <version>0.0.45</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Maven -->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Project related -->
         <spring.rdf.migration.version>2.0.0</spring.rdf.migration.version>

--- a/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/schema/data/MetadataSchemaFixtures.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/development/schema/data/MetadataSchemaFixtures.java
@@ -59,6 +59,7 @@ public class MetadataSchemaFixtures {
                 .version(VERSION)
                 .versionString(VERSION.toString())
                 .name(name)
+                .description("")
                 .definition(definition)
                 .targetClasses(targetClasses)
                 .extendSchemas(extendsSchemas)

--- a/src/main/java/nl/dtls/fairdatapoint/service/jwt/JwtService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/jwt/JwtService.java
@@ -73,7 +73,7 @@ public class JwtService {
     protected void init() {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
         key = new SecretKeySpec(secretKey.getBytes(), SignatureAlgorithm.HS256.getJcaName());
-        parser = Jwts.parserBuilder().setSigningKey(key).build();
+        parser = Jwts.parser().setSigningKey(key).build();
     }
 
     public String createToken(AuthDTO authDTO) {
@@ -94,13 +94,13 @@ public class JwtService {
     }
 
     public String getUserUuid(String token) {
-        return parser.parseClaimsJws(token).getBody().getSubject();
+        return parser.parseClaimsJws(token).getPayload().getSubject();
     }
 
     public boolean validateToken(String token) {
         try {
             final Jws<Claims> claims = parser.parseClaimsJws(token);
-            return !claims.getBody().getExpiration().before(new Date());
+            return !claims.getPayload().getExpiration().before(new Date());
         }
         catch (JwtException | IllegalArgumentException exception) {
             throw new UnauthorizedException("Expired or invalid JWT token");
@@ -108,13 +108,13 @@ public class JwtService {
     }
 
     private String buildToken(User user) {
-        final Claims claims = Jwts.claims().setSubject(user.getUuid());
+        final Claims claims = Jwts.claims().subject(user.getUuid().toString()).build();
         final Date now = new Date();
         final Date validity = new Date(now.getTime() + (expiration * DAY_MS));
         return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(validity)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(validity)
                 .signWith(key)
                 .compact();
     }

--- a/src/main/java/nl/dtls/fairdatapoint/service/metadata/state/MetadataStateService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/metadata/state/MetadataStateService.java
@@ -44,7 +44,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static nl.dtls.fairdatapoint.entity.metadata.MetadataGetter.getUri;
 import static nl.dtls.fairdatapoint.util.RdfUtil.getObjectsBy;
 import static nl.dtls.fairdatapoint.util.ValueFactoryHelper.i;
 

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/openapi/SwaggerUI_GET.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/openapi/SwaggerUI_GET.java
@@ -27,6 +27,7 @@ import nl.dtls.fairdatapoint.api.dto.index.entry.IndexEntryDTO;
 import nl.dtls.fairdatapoint.utils.CustomPageImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -61,7 +62,8 @@ public class SwaggerUI_GET extends WebIntegrationTest {
                 .build();
 
         // WHEN
-        ResponseEntity<String> result = client.exchange(request, new ParameterizedTypeReference<>() {});
+        ResponseEntity<String> result = client.withRedirects(ClientHttpRequestFactorySettings.Redirects.DONT_FOLLOW)
+                .exchange(request, new ParameterizedTypeReference<>() {});
 
         // THEN
         assertThat("Response code is FOUND", result.getStatusCode(), is(equalTo(HttpStatus.FOUND)));

--- a/src/test/java/nl/dtls/fairdatapoint/acceptance/schema/Import_POST.java
+++ b/src/test/java/nl/dtls/fairdatapoint/acceptance/schema/Import_POST.java
@@ -23,7 +23,6 @@
 package nl.dtls.fairdatapoint.acceptance.schema;
 
 import nl.dtls.fairdatapoint.WebIntegrationTest;
-import nl.dtls.fairdatapoint.api.dto.schema.MetadataSchemaRemoteDTO;
 import nl.dtls.fairdatapoint.api.dto.schema.MetadataSchemaVersionDTO;
 import nl.dtls.fairdatapoint.database.mongo.migration.development.schema.data.MetadataSchemaFixtures;
 import nl.dtls.fairdatapoint.database.mongo.repository.MetadataSchemaRepository;
@@ -73,6 +72,8 @@ public class Import_POST extends WebIntegrationTest {
                 .description(metadataSchemaFixtures.customSchema().getDescription())
                 .definition(metadataSchemaFixtures.customSchema().getDefinition())
                 .abstractSchema(metadataSchemaFixtures.customSchema().isAbstractSchema())
+                .type(metadataSchemaFixtures.customSchema().getType())
+                .targetClasses(metadataSchemaFixtures.customSchema().getTargetClasses())
                 .extendsSchemaUuids(Collections.emptyList())
                 .build();
     }
@@ -91,6 +92,8 @@ public class Import_POST extends WebIntegrationTest {
                 .description(metadataSchemaFixtures.customSchema().getDescription())
                 .definition(metadataSchemaFixtures.customSchema().getDefinition())
                 .abstractSchema(metadataSchemaFixtures.customSchema().isAbstractSchema())
+                .type(metadataSchemaFixtures.customSchema().getType())
+                .targetClasses(metadataSchemaFixtures.customSchema().getTargetClasses())
                 .extendsSchemaUuids(Collections.emptyList())
                 .build();
     }


### PR DESCRIPTION
Upgrade dependencies to match current develop branch:

- upgraded JDK from 17 to 21
- upgraded various dependencies in pom.xml
- removed redundant spring-data-mongodb version pin to fix conflict
- adapted deprecated references in `JwtService` class to match develop