### PR TITLE
fix: don't update creation and modification data of catalog

### DIFF
--- a/src/main/java/nl/dtls/fairdatapoint/entity/metadata/MetadataSetter.java
+++ b/src/main/java/nl/dtls/fairdatapoint/entity/metadata/MetadataSetter.java
@@ -105,14 +105,6 @@ public class MetadataSetter {
         update(metadata, uri, FDP.METADATAMODIFIED, dateTime);
     }
 
-    public static void setMetadataIssued(Model metadata, IRI uri, Literal dataRecordIssued) {
-        update(metadata, uri, DCTERMS.ISSUED, dataRecordIssued);
-    }
-
-    public static void setMetadataModified(Model metadata, IRI uri, Literal dataRecordModified) {
-        update(metadata, uri, DCTERMS.MODIFIED, dataRecordModified);
-    }
-
     // ------------------------------------------------------------------------------
     //  Custom
     // ------------------------------------------------------------------------------

--- a/src/main/java/nl/dtls/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
@@ -90,9 +90,6 @@ public class MetadataEnhancer {
 
         // Populate with current data from the triple store
         setIssued(metadata, uri, l(getIssued(oldMetadata)));
-        if (definition.isCatalog()) {
-            setMetadataIssued(metadata, uri, l(getMetadataIssued(oldMetadata)));
-        }
     }
 
     public void enhance(Model metadata, IRI uri, ResourceDefinition definition) {
@@ -136,10 +133,6 @@ public class MetadataEnhancer {
         final OffsetDateTime timestamp = OffsetDateTime.now();
         setIssued(metadata, uri, l(timestamp));
         setModified(metadata, uri, l(timestamp));
-        if (definition.isCatalog()) {
-            setMetadataIssued(metadata, uri, l(timestamp));
-            setMetadataModified(metadata, uri, l(timestamp));
-        }
     }
 
     public void enhanceWithLinks(IRI entityUri, Model entity, ResourceDefinition definition, String url,


### PR DESCRIPTION
fixes #686

Issued and modified dates in catalog, are about the catalog itself, they should not be updated when you update the metadata.