### PR TITLE
Include httpclient5 dependency in compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,6 @@
         <lombok.version>1.18.38</lombok.version>
         <hypersistence.version>3.9.10</hypersistence.version>
 
-        <!-- Test -->
-        <httpclient5.version>5.5</httpclient5.version>
-
         <!-- Plugins -->
         <plugin.license.version>5.0.0</plugin.license.version>
         <plugin.jacoco.version>0.7.6.201602180812</plugin.jacoco.version>
@@ -237,7 +234,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>${httpclient5.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
For some reason the `httpclient5` dependency in `pom.xml` was only included in the `test` [scope].

For earlier versions of spring this was not a problem, but something must have changed in recent spring-boot to cause #645. Probably this is due to [apache-httpclient-in-resttemplate], because our errors indeed occur as a result of `RestTemplate` calls.

Made the following changes to fix this:

- removed explicit `test` scope from the `httpclient5` dependency, to make sure it is included in the default (`compile`) scope
- removed explicit version for `httpclient5`, because this is actually a spring-boot [managed dependency]

Now pings are executed properly (the status 403 below is expected because pings from localhost are denied by index):

```none
2025-07-02 17:52:09,129 31362 [scheduling-1] DEBUG org.springframework.web.client.RestTemplate - Writing [{clientUrl=http://localhost:8080}] with org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
2025-07-02 17:52:09,146 31379 [scheduling-1] DEBUG org.springframework.web.client.RestTemplate - Response 403 FORBIDDEN
2025-07-02 17:52:09,147 31380 [scheduling-1] WARN  org.fairdatapoint.service.ping.PingService - Failed to ping http://localhost:8082: 403  on POST request for "http://localhost:8082": "{"timestamp":1751471529144,"status":403,"error":"Forbidden","message":"Client URL is denied: http://localhost:8080"}"
```

fixes #645

related:
- #706

[managed dependency]: https://docs.spring.io/spring-boot/appendix/dependency-versions/coordinates.html
[scope]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope
[apache-httpclient-in-resttemplate]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#apache-httpclient-in-resttemplate