### PR TITLE
Fix dependabot group exclude-pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
           - "minor"
           - "patch"
         exclude-patterns:
-          - "spring-boot-starter-parent"
+          - "*spring-boot-starter-parent*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
add wildcards for `spring-boot-starter-parent` pattern to make sure it is excluded from the group
