### PR TITLE
Remove hard-coded project version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,3 +32,5 @@ jobs:
     with:
       file: './Dockerfile'
       push: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+      build-args: |
+        "PROJECT_VERSION=${{ github.ref_name }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Docker build
         run: |
           docker pull $PUBLIC_IMAGE:$IMAGE_TAG
-          docker build --cache-from $PUBLIC_IMAGE:$IMAGE_TAG -t fdp:snyk-test -f Dockerfile .
+          docker build --build-arg PROJECT_VERSION=x.y.z --cache-from $PUBLIC_IMAGE:$IMAGE_TAG -t fdp:snyk-test -f Dockerfile .
 
       - name: Perform Snyk Check (Docker)
         uses: snyk/actions/docker@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 ################################################################################
 # BUILD JAR
 
-ARG PROJECT_VERSION
-
 FROM maven:3-eclipse-temurin-21-alpine AS builder
 
 WORKDIR /builder
@@ -13,6 +11,7 @@ WORKDIR /builder
 ADD . /builder
 
 # https://maven.apache.org/ref/current/maven-embedder/cli.html
+ARG PROJECT_VERSION
 RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests -Drevision=${PROJECT_VERSION} package
 
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 ################################################################################
 # BUILD JAR
 
+ARG PROJECT_VERSION
+
 FROM maven:3-eclipse-temurin-21-alpine AS builder
 
 WORKDIR /builder
@@ -11,7 +13,7 @@ WORKDIR /builder
 ADD . /builder
 
 # https://maven.apache.org/ref/current/maven-embedder/cli.html
-RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests package
+RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests -Drevision=${PROJECT_VERSION} package
 
 ################################################################################
 # BUILD IMAGE

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,20 +3,20 @@
 ## Supported Versions
 
 We support the latest *major* and *minor* version with *patch* versions that fix vulnerabilities and critical bugs.
-For older versions, we highly recommend upgrading to the latest version. 
+For older versions, we highly recommend upgrading to the [latest] version. 
 
-| Version | Supported          |
-|---------| ------------------ |
-| 1.20.x  | :white_check_mark: |
-| < 1.20  | :x:                |
+| Version    | Supported          |
+|------------| ------------------ |
+| [latest]   | :white_check_mark: |
+| < [latest] | :x:                |
 
 ## Current Recommendations
 
-* Always use the [latest release]. 
+* Always use the [latest] release. 
 
 ## Reporting a Vulnerability
 
 If you encounter a vulnerability, please create a [private security advisory] using the "Report a vulnerability" button at the top of this page.
 
 [private security advisory]: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability
-[latest release]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/latest
+[latest]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/latest

--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,10 @@
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/META-INF/git.properties</generateGitPropertiesFilename>
                     <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <!-- include lightweight tags in git describe (github release creates lightweight tags) -->
+                    <gitDescribe>
+                        <tags>true</tags>
+                    </gitDescribe>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.fairdatateam</groupId>
     <artifactId>fairdatapoint</artifactId>
-    <version>1.20.0</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <name>FairDataPoint</name>
@@ -45,6 +45,8 @@
     <properties>
         <!-- Project -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- revision defaults to the major version, and should be overridden during build, e.g. `mvn -Drevision=1.20.2 ...` -->
+        <revision>1</revision>
 
         <!-- Maven -->
         <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     <properties>
         <!-- Project -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- revision defaults to the major version, and should be overridden during build, e.g. `mvn -Drevision=1.20.2 ...` -->
-        <revision>1</revision>
+        <!-- revision should be overridden during build, e.g. `mvn -Drevision=v1.20.2 ...` -->
+        <revision>dev</revision>
 
         <!-- Maven -->
         <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,8 @@
     <properties>
         <!-- Project -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- revision should be overridden during build, e.g. `mvn -Drevision=v1.20.2 ...` -->
+        <!-- The `revision` property should be overridden during build, e.g. `mvn -Drevision=v1.20.2 ...` -->
+        <!-- This is handled automatically in the `docker-publish.yml` workflow, with the help of `PROJECT_VERSION`. -->
         <revision>dev</revision>
 
         <!-- Maven -->

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,7 @@ metadataProperties:
 
 openapi:
   title: FAIR Data Point API
-  version: 1.20.0
+  version: "@project.version@"
   description: "The reference implementation of the metadata registration service: A service implementing the API specification. It contains an authentication system to allow maintainers to define and update metadata. Read-only access to the data is public."
   contact:
     name: Luiz Bonino


### PR DESCRIPTION
This removes the hard-coded project version from the `pom.xml` and `application.yml`, so git tags and code cannot get out of sync.

- use maven `revision` property to enable command line override of `project.version` in pom
  (set default to `dev`, so it's clear when version is not provided)
- assign `project.version` to `openapi.version` in `application.yml`
- override `project.version` using git tag in github docker build workflow
- fix output of `git describe` in the generated `git.properties` file, by including lightweight tags


fixes #624

### notes

- The version returned by `/actuator/info` (client "about" link) already comes from the git ref, and so does the version in the docker image name.
- If we could assign the git tag to `project.version` directly in the pom, there would be no need to modify the github workflows and Dockerfile. However, although `git-commit-id-maven-plugin` can expose the git info to the pom, I don't think this can be used to set the maven `project.version` directly. For example, `${git.commit.id.describe-short}` is not evaluated when used inside the project version tag, despite enabling `injectAllReactorProjects` in the plugin config.
- An alternative would be to use an additional dependency like `qoomon/maven-git-versioning-extension`, but we should minimize the number of dependencies.

