### PR TITLE
Rely on spring-boot managed versions for lombok and postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         
         <!-- Core -->
         <springdoc.version>2.8.12</springdoc.version>
-        <postgresql.version>42.7.7</postgresql.version>
         <rdf4j.version>5.1.4</rdf4j.version>
         <jwt.version>0.13.0</jwt.version>
         <hypersistence.version>3.10.3</hypersistence.version>
@@ -207,7 +206,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Removed explicit versions for the following packages, relying on [spring-boot managed dependencies][1] instead:

- lombok
- postgresql

fixes #787

[1]: https://docs.spring.io/spring-boot/appendix/dependency-versions/coordinates.html