### PR TITLE
Bump github actions runner from windows-2022 to windows-2025

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         runner:
+          # https://github.com/actions/runner-images
           - ubuntu-24.04
-          - windows-2022
+          - windows-2025
           - macos-14
         java-version:
           - 21


### PR DESCRIPTION
Bump windows runner in maven-verify workflow to latest windows-2025.
