### PR TITLE
Make test logging config easier to use

### DIFF
--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn">
+<Configuration status="WARN">
     <Appenders>
         <Console name="console-log" target="SYSTEM_OUT">
             <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
@@ -7,12 +7,9 @@
     </Appenders>
     <Loggers>
         <!-- set log levels for individual packages (add or change as needed) -->
-        <Logger name="org.springframework" level="error"/>
-        <Logger name="org.springframework.data.repository" level="error"/>
-        <!-- suppress "expected" error messages to prevent confusion when reading successful test results -->
-        <Logger name="org.fairdatapoint.api.controller.exception" level="fatal"/>
-        <!-- set root level to limit the amount of test output clutter -->
-        <Root level="error">
+        <Logger name="org.springframework" level="off"/>
+        <!-- set root log level to limit the amount of test output clutter -->
+        <Root level="off">
             <AppenderRef ref="console-log"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
Current test logging config [log4j2.xml](./test/resources/log4j2.xml) does not produce any useful output at all during tests, except for the rudimentary test summaries from the test framework itself. Normal log messages, like those we see when running the app, are suppressed:

https://github.com/FAIRDataTeam/FAIRDataPoint/blob/97a23a086ce55101773ad9edb9c75f0595cc11b1/src/test/resources/log4j2.xml#L11

Normally this is good, because it prevents clutter, but it can also complicate "debugging."

This PR keeps the same default `level="off"`, but makes it easier to enable normal logging temporarily, when required:

- renamed `log4j2.xml` to `log4j2-test.xml`, to be more explicit, and more conformant to [log4j autoconfig]
- added AppenderRef to root logger config, so we only need to change the level when needed

[log4j autoconfig]: https://logging.apache.org/log4j/2.3.x/manual/configuration.html#AutomaticConfiguration





replaces #803