### PR TITLE
Prevent duplicated related items when updating ResourceDefinition

### DIFF
--- a/src/main/java/org/fairdatapoint/service/resource/ResourceDefinitionService.java
+++ b/src/main/java/org/fairdatapoint/service/resource/ResourceDefinitionService.java
@@ -257,7 +257,14 @@ public class ResourceDefinitionService {
     @PreAuthorize("hasRole('ADMIN')")
     protected void deleteChild(ResourceDefinitionChild child) {
         childMetadataRepository.deleteAll(child.getMetadata());
-        childRepository.delete(child);
+        // Remember `child` is not actually a child but rather a link entity,
+        // where `source` is the parent and `target` is the actual child (#821).
+        // We need to clear both sides of the bi-directional relation.
+        // todo: refactor after fixing #825
+        child.getSource().getChildren().remove(child);
+        child.getTarget().getParents().remove(child);
+        child.setSource(null);
+        child.setTarget(null);
     }
 
     public List<String> getTargetClassUris(ResourceDefinition resourceDefinition) {

--- a/src/main/java/org/fairdatapoint/service/resource/ResourceDefinitionService.java
+++ b/src/main/java/org/fairdatapoint/service/resource/ResourceDefinitionService.java
@@ -246,7 +246,8 @@ public class ResourceDefinitionService {
     @Transactional
     @PreAuthorize("hasRole('ADMIN')")
     protected void deleteDependents(ResourceDefinition resourceDefinition) {
-        resourceDefinition.getChildren().forEach(this::deleteChild);
+        // Copy the list of children because we need to modify it (prevent ConcurrentModificationException)
+        List.copyOf(resourceDefinition.getChildren()).forEach(this::deleteChild);
         linkRepository.deleteAll(resourceDefinition.getExternalLinks());
         usageRepository.deleteAll(resourceDefinition.getMetadataSchemaUsages());
         entityManager.flush();

--- a/src/main/java/org/fairdatapoint/service/resource/ResourceDefinitionService.java
+++ b/src/main/java/org/fairdatapoint/service/resource/ResourceDefinitionService.java
@@ -246,9 +246,13 @@ public class ResourceDefinitionService {
     @Transactional
     @PreAuthorize("hasRole('ADMIN')")
     protected void deleteDependents(ResourceDefinition resourceDefinition) {
-        // Copy the list of children because we need to modify it (prevent ConcurrentModificationException)
+        // Iterate over list copies because we need to modify the originals (prevent ConcurrentModificationException)
+        // todo: refactor after fixing #825
         List.copyOf(resourceDefinition.getChildren()).forEach(this::deleteChild);
-        linkRepository.deleteAll(resourceDefinition.getExternalLinks());
+        List.copyOf(resourceDefinition.getExternalLinks()).forEach(link -> {
+            resourceDefinition.getExternalLinks().remove(link);
+            linkRepository.delete(link);
+        });
         usageRepository.deleteAll(resourceDefinition.getMetadataSchemaUsages());
         entityManager.flush();
         entityManager.refresh(resourceDefinition);

--- a/src/test/java/org/fairdatapoint/acceptance/resource/Detail_PUT.java
+++ b/src/test/java/org/fairdatapoint/acceptance/resource/Detail_PUT.java
@@ -24,7 +24,6 @@ package org.fairdatapoint.acceptance.resource;
 
 import org.fairdatapoint.WebIntegrationTest;
 import org.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
-import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildDTO;
 import org.fairdatapoint.api.dto.resource.ResourceDefinitionDTO;
 import org.fairdatapoint.database.db.repository.ResourceDefinitionRepository;
 import org.fairdatapoint.entity.resource.ResourceDefinition;
@@ -37,7 +36,6 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 
 import java.net.URI;
-import java.util.List;
 import java.util.UUID;
 
 import static java.lang.String.format;

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @AutoConfigureTestEntityManager
 @Transactional  // required for TestEntityManager outside of @DataJpaTest
@@ -83,7 +84,8 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
     }
 
     /**
-     * Reproduces #830
+     * Reproduces #830, under the assumption that at least one of the default resources has children
+     * (in this case fdp, catalog, and dataset) and at least one of the resources has external links (distribution).
      */
     @ParameterizedTest
     @MethodSource("uuidProvider")
@@ -97,6 +99,7 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
         final int expectedParentCount = resourceDefinition.getParents().size();
         final int expectedExternalLinkCount =  resourceDefinition.getExternalLinks().size();
         final int expectedMetadataSchemaUsageCount = resourceDefinition.getMetadataSchemaUsages().size();
+        assertTrue(expectedMetadataSchemaUsageCount > 0);
         // call update method
         resourceDefinitionService.update(uuid, changeDTO);
         // check for duplicates (or other inconsistencies in the number of related items)

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -24,13 +24,8 @@ package org.fairdatapoint.service.resource;
 
 import org.fairdatapoint.BaseIntegrationTest;
 import org.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
-import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildDTO;
-import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildListViewDTO;
-import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildListViewMetadataDTO;
 import org.fairdatapoint.entity.resource.ResourceDefinition;
-import org.fairdatapoint.entity.resource.ResourceDefinitionChild;
-import org.fairdatapoint.entity.resource.ResourceDefinitionChildMetadata;
-import org.junit.jupiter.api.BeforeEach;
+import org.fairdatapoint.util.KnownUUIDs;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
@@ -40,7 +35,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindException;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +47,8 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
 
     final ResourceDefinitionService resourceDefinitionService;
 
+    final ResourceDefinitionMapper resourceDefinitionMapper;
+
     final TestEntityManager testEntityManager;
 
     /**
@@ -63,109 +59,23 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
     @Autowired
     public ResourceDefinitionServiceTest(
             ResourceDefinitionService resourceDefinitionService,
+            ResourceDefinitionMapper resourceDefinitionMapper,
             TestEntityManager testEntityManager
     ) {
         this.resourceDefinitionService = resourceDefinitionService;
+        this.resourceDefinitionMapper = resourceDefinitionMapper;
         this.testEntityManager = testEntityManager;
-    }
-
-    /**
-     * Creates ResourceDefinitionChangeDTO from existing ResourceDefinition
-     *
-     * @param uuid ResourceDefinition identifier
-     * @return Change DTO based on the ResourceDefinition
-     */
-    private ResourceDefinitionChangeDTO createResourceDefinitionChangeDTO(UUID uuid) {
-        ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
-        System.out.println(resourceDefinition.getChildren().size());  // TEMP
-        final ResourceDefinitionChangeDTO dto = new ResourceDefinitionChangeDTO();
-        dto.setName(resourceDefinition.getName());
-        dto.setUrlPrefix(resourceDefinition.getUrlPrefix());
-        dto.setMetadataSchemaUuids(resourceDefinition.getMetadataSchemaUsages()
-                .stream()
-                .map(usage -> usage.getUsedMetadataSchema().getUuid())
-                .toList()
-        );
-        dto.setChildren(resourceDefinition.getChildren()
-                .stream()
-                .map(child -> new ResourceDefinitionChildDTO(
-                        child.getTarget().getUuid(),
-                        child.getRelationUri(),
-                        new ResourceDefinitionChildListViewDTO(
-                                child.getTitle(),
-                                child.getTagsUri(),
-                                child.getMetadata()
-                                        .stream()
-                                        .map(
-                                                metadata -> new ResourceDefinitionChildListViewMetadataDTO(
-                                                        metadata.getTitle(), metadata.getPropertyUri()
-                                                )
-                                        ).toList()
-                        )
-                ))
-                .toList()
-        );
-        dto.setExternalLinks(List.of());  // TEMP
-// TODO:
-//        dto.setExternalLinks(resourceDefinition.getExternalLinks()
-//                .stream()
-//                .map()
-//                .toList()
-//        );
-        return dto;
-    }
-
-    @BeforeEach
-    public void setUp() {
-        // create child resource
-        ResourceDefinition child = new ResourceDefinition();
-        child.setName("child resource");
-        child.setUrlPrefix("child");
-        child.setChildren(List.of());
-        child.setParents(List.of());
-        child.setExternalLinks(List.of());
-        child.setMetadataSchemaUsages(List.of());
-        child = testEntityManager.persist(child);
-        uuids.put("child", child.getUuid());
-        // create parent resource
-        ResourceDefinition parent = new ResourceDefinition();
-        parent.setName("parent resource");
-        parent.setUrlPrefix("parent");
-        parent.setExternalLinks(List.of());
-        parent.setMetadataSchemaUsages(List.of());
-        parent = testEntityManager.persist(parent);
-        uuids.put("parent", parent.getUuid());
-        // create parent-child relation
-        ResourceDefinitionChild relation = new ResourceDefinitionChild();
-        relation.setRelationUri("http://example.org/relation");
-        relation.setTitle("relation");
-        relation.setOrderPriority(1);
-        relation.setSource(parent);
-        relation.setTarget(child);
-        relation = testEntityManager.persist(relation);
-        uuids.put("relation", relation.getUuid());
-        // manage both sides of bidirectional relations
-        parent.setChildren(List.of(relation));
-        child.setParents(List.of(relation));
-        // create relation metadata
-        ResourceDefinitionChildMetadata relationMetadata = new ResourceDefinitionChildMetadata();
-        relationMetadata.setTitle("relation metadata");
-        relationMetadata.setPropertyUri("http://example.org/property");
-        relationMetadata.setOrderPriority(1);
-        relationMetadata.setChild(relation);
-        relationMetadata = testEntityManager.persist(relationMetadata);
-        relation.setMetadata(List.of(relationMetadata));
-        // flushed by transaction
     }
 
     @Test
     @WithMockUser(roles="ADMIN")
-    public void testUpdate() throws BindException {
-        final UUID parentUuid = uuids.get("parent");
-        ResourceDefinitionChangeDTO changeDTO = createResourceDefinitionChangeDTO(parentUuid);
-        System.out.println(changeDTO.getName());
-        resourceDefinitionService.update(parentUuid, changeDTO);
-        ResourceDefinition updatedResourceDefinition = testEntityManager.find(ResourceDefinition.class, parentUuid);
-        assertEquals(1,  updatedResourceDefinition.getChildren().size());
+    public void testUpdateDoesNotDuplicateChildren() throws BindException {
+        // reproduces #830
+        final UUID uuid = KnownUUIDs.RD_CATALOG_UUID;
+        ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
+        ResourceDefinitionChangeDTO changeDTO = resourceDefinitionMapper.toChangeDTO(resourceDefinition);
+        resourceDefinitionService.update(uuid, changeDTO);
+        testEntityManager.refresh(resourceDefinition);
+        assertEquals(1,  resourceDefinition.getChildren().size());
     }
 }

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -1,0 +1,55 @@
+package org.fairdatapoint.service.resource;
+
+import org.fairdatapoint.BaseIntegrationTest;
+import org.fairdatapoint.entity.resource.ResourceDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@AutoConfigureTestEntityManager
+@Transactional  // required for TestEntityManager outside of @DataJpaTest
+public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
+
+    UUID uuid;
+
+    final ResourceDefinitionService resourceDefinitionService;
+
+    final TestEntityManager testEntityManager;
+
+    /**
+     * Constructor
+     * @param resourceDefinitionService The service to test
+     */
+    @Autowired
+    public ResourceDefinitionServiceTest(
+            ResourceDefinitionService resourceDefinitionService,
+            TestEntityManager testEntityManager
+    ) {
+        this.resourceDefinitionService = resourceDefinitionService;
+        this.testEntityManager = testEntityManager;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        ResourceDefinition resourceDefinition = new ResourceDefinition();
+        resourceDefinition.setName("test");
+        resourceDefinition.setUrlPrefix("test");
+        resourceDefinition.setChildren(List.of());
+        resourceDefinition.setParents(List.of());
+        resourceDefinition.setExternalLinks(List.of());
+        resourceDefinition.setMetadataSchemaUsages(List.of());
+        resourceDefinition = testEntityManager.persist(resourceDefinition);
+        uuid = resourceDefinition.getUuid();
+    }
+
+    @Test
+    public void testUpdate() {
+        ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
+    }
+}

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -23,22 +23,33 @@
 package org.fairdatapoint.service.resource;
 
 import org.fairdatapoint.BaseIntegrationTest;
+import org.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
+import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildDTO;
+import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildListViewDTO;
+import org.fairdatapoint.api.dto.resource.ResourceDefinitionChildListViewMetadataDTO;
 import org.fairdatapoint.entity.resource.ResourceDefinition;
+import org.fairdatapoint.entity.resource.ResourceDefinitionChild;
+import org.fairdatapoint.entity.resource.ResourceDefinitionChildMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BindException;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @AutoConfigureTestEntityManager
 @Transactional  // required for TestEntityManager outside of @DataJpaTest
 public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
 
-    UUID uuid;
+    final HashMap<String, UUID> uuids = new HashMap<>();
 
     final ResourceDefinitionService resourceDefinitionService;
 
@@ -46,6 +57,7 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
 
     /**
      * Constructor
+     *
      * @param resourceDefinitionService The service to test
      */
     @Autowired
@@ -57,21 +69,103 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
         this.testEntityManager = testEntityManager;
     }
 
+    /**
+     * Creates ResourceDefinitionChangeDTO from existing ResourceDefinition
+     *
+     * @param uuid ResourceDefinition identifier
+     * @return Change DTO based on the ResourceDefinition
+     */
+    private ResourceDefinitionChangeDTO createResourceDefinitionChangeDTO(UUID uuid) {
+        ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
+        System.out.println(resourceDefinition.getChildren().size());  // TEMP
+        final ResourceDefinitionChangeDTO dto = new ResourceDefinitionChangeDTO();
+        dto.setName(resourceDefinition.getName());
+        dto.setUrlPrefix(resourceDefinition.getUrlPrefix());
+        dto.setMetadataSchemaUuids(resourceDefinition.getMetadataSchemaUsages()
+                .stream()
+                .map(usage -> usage.getUsedMetadataSchema().getUuid())
+                .toList()
+        );
+        dto.setChildren(resourceDefinition.getChildren()
+                .stream()
+                .map(child -> new ResourceDefinitionChildDTO(
+                        child.getTarget().getUuid(),
+                        child.getRelationUri(),
+                        new ResourceDefinitionChildListViewDTO(
+                                child.getTitle(),
+                                child.getTagsUri(),
+                                child.getMetadata()
+                                        .stream()
+                                        .map(
+                                                metadata -> new ResourceDefinitionChildListViewMetadataDTO(
+                                                        metadata.getTitle(), metadata.getPropertyUri()
+                                                )
+                                        ).toList()
+                        )
+                ))
+                .toList()
+        );
+        dto.setExternalLinks(List.of());  // TEMP
+// TODO:
+//        dto.setExternalLinks(resourceDefinition.getExternalLinks()
+//                .stream()
+//                .map()
+//                .toList()
+//        );
+        return dto;
+    }
+
     @BeforeEach
     public void setUp() {
-        ResourceDefinition resourceDefinition = new ResourceDefinition();
-        resourceDefinition.setName("test");
-        resourceDefinition.setUrlPrefix("test");
-        resourceDefinition.setChildren(List.of());
-        resourceDefinition.setParents(List.of());
-        resourceDefinition.setExternalLinks(List.of());
-        resourceDefinition.setMetadataSchemaUsages(List.of());
-        resourceDefinition = testEntityManager.persist(resourceDefinition);
-        uuid = resourceDefinition.getUuid();
+        // create child resource
+        ResourceDefinition child = new ResourceDefinition();
+        child.setName("child resource");
+        child.setUrlPrefix("child");
+        child.setChildren(List.of());
+        child.setParents(List.of());
+        child.setExternalLinks(List.of());
+        child.setMetadataSchemaUsages(List.of());
+        child = testEntityManager.persist(child);
+        uuids.put("child", child.getUuid());
+        // create parent resource
+        ResourceDefinition parent = new ResourceDefinition();
+        parent.setName("parent resource");
+        parent.setUrlPrefix("parent");
+        parent.setExternalLinks(List.of());
+        parent.setMetadataSchemaUsages(List.of());
+        parent = testEntityManager.persist(parent);
+        uuids.put("parent", parent.getUuid());
+        // create parent-child relation
+        ResourceDefinitionChild relation = new ResourceDefinitionChild();
+        relation.setRelationUri("http://example.org/relation");
+        relation.setTitle("relation");
+        relation.setOrderPriority(1);
+        relation.setSource(parent);
+        relation.setTarget(child);
+        relation = testEntityManager.persist(relation);
+        uuids.put("relation", relation.getUuid());
+        // manage both sides of bidirectional relations
+        parent.setChildren(List.of(relation));
+        child.setParents(List.of(relation));
+        // create relation metadata
+        ResourceDefinitionChildMetadata relationMetadata = new ResourceDefinitionChildMetadata();
+        relationMetadata.setTitle("relation metadata");
+        relationMetadata.setPropertyUri("http://example.org/property");
+        relationMetadata.setOrderPriority(1);
+        relationMetadata.setChild(relation);
+        relationMetadata = testEntityManager.persist(relationMetadata);
+        relation.setMetadata(List.of(relationMetadata));
+        // flushed by transaction
     }
 
     @Test
-    public void testUpdate() {
-        ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
+    @WithMockUser(roles="ADMIN")
+    public void testUpdate() throws BindException {
+        final UUID parentUuid = uuids.get("parent");
+        ResourceDefinitionChangeDTO changeDTO = createResourceDefinitionChangeDTO(parentUuid);
+        System.out.println(changeDTO.getName());
+        resourceDefinitionService.update(parentUuid, changeDTO);
+        ResourceDefinition updatedResourceDefinition = testEntityManager.find(ResourceDefinition.class, parentUuid);
+        assertEquals(1,  updatedResourceDefinition.getChildren().size());
     }
 }

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -26,7 +26,8 @@ import org.fairdatapoint.BaseIntegrationTest;
 import org.fairdatapoint.api.dto.resource.ResourceDefinitionChangeDTO;
 import org.fairdatapoint.entity.resource.ResourceDefinition;
 import org.fairdatapoint.util.KnownUUIDs;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -36,6 +37,7 @@ import org.springframework.validation.BindException;
 
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -68,14 +70,26 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
     }
 
     /**
-     * Reproduces #830
-     * @throws BindException
+     * Provides arguments for @ParameterizedTest
+     * @return UUID of resource
      */
-    @Test
+    static Stream<UUID> uuidProvider() {
+        return Stream.of(
+                KnownUUIDs.RD_FDP_UUID,
+                KnownUUIDs.RD_CATALOG_UUID,
+                KnownUUIDs.RD_DATASET_UUID,
+                KnownUUIDs.RD_DISTRIBUTION_UUID
+        );
+    }
+
+    /**
+     * Reproduces #830
+     */
+    @ParameterizedTest
+    @MethodSource("uuidProvider")
     @WithMockUser(roles="ADMIN")
-    public void testUpdateDoesNotDuplicateChildren() throws BindException {
+    public void testUpdateDoesNotDuplicateRelatedItems(UUID uuid) throws BindException {
         // create DTO from existing resource (without making any actual changes)
-        final UUID uuid = KnownUUIDs.RD_CATALOG_UUID;
         ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
         ResourceDefinitionChangeDTO changeDTO = resourceDefinitionMapper.toChangeDTO(resourceDefinition);
         // count related items, for reference

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -1,3 +1,25 @@
+/**
+ * The MIT License
+ * Copyright © 2016-2024 FAIR Data Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.fairdatapoint.service.resource;
 
 import org.fairdatapoint.BaseIntegrationTest;

--- a/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
+++ b/src/test/java/org/fairdatapoint/service/resource/ResourceDefinitionServiceTest.java
@@ -67,15 +67,29 @@ public class ResourceDefinitionServiceTest extends BaseIntegrationTest {
         this.testEntityManager = testEntityManager;
     }
 
+    /**
+     * Reproduces #830
+     * @throws BindException
+     */
     @Test
     @WithMockUser(roles="ADMIN")
     public void testUpdateDoesNotDuplicateChildren() throws BindException {
-        // reproduces #830
+        // create DTO from existing resource (without making any actual changes)
         final UUID uuid = KnownUUIDs.RD_CATALOG_UUID;
         ResourceDefinition resourceDefinition = testEntityManager.find(ResourceDefinition.class, uuid);
         ResourceDefinitionChangeDTO changeDTO = resourceDefinitionMapper.toChangeDTO(resourceDefinition);
+        // count related items, for reference
+        final int expectedChildCount = resourceDefinition.getChildren().size();
+        final int expectedParentCount = resourceDefinition.getParents().size();
+        final int expectedExternalLinkCount =  resourceDefinition.getExternalLinks().size();
+        final int expectedMetadataSchemaUsageCount = resourceDefinition.getMetadataSchemaUsages().size();
+        // call update method
         resourceDefinitionService.update(uuid, changeDTO);
+        // check for duplicates (or other inconsistencies in the number of related items)
         testEntityManager.refresh(resourceDefinition);
-        assertEquals(1,  resourceDefinition.getChildren().size());
+        assertEquals(expectedChildCount, resourceDefinition.getChildren().size());
+        assertEquals(expectedParentCount, resourceDefinition.getParents().size());
+        assertEquals(expectedExternalLinkCount, resourceDefinition.getExternalLinks().size());
+        assertEquals(expectedMetadataSchemaUsageCount, resourceDefinition.getMetadataSchemaUsages().size());
     }
 }


### PR DESCRIPTION
- added test to reproduce #830
- fixed `deleteDependents` by clearing both sides of the bidirectional relations for children and external links

fixes #830