### PR TITLE
Bump mongodb from 5 to 7 for windows runners in maven-verify workflow

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -22,7 +22,7 @@ jobs:
           - os: ubuntu-24.04
             mongo: 8
           - os: windows-2022
-            mongo: 5
+            mongo: 7
           - os: macos-14
             mongo: 8
         java-version:


### PR DESCRIPTION
setup-mongodb now only supports mongo 7 on windows runners

see ankane/setup-mongodb 2d78f75