### PR TITLE
Fix API doc generation for resource endpoints

### DIFF
--- a/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/openapi/OpenApiService.java
@@ -29,7 +29,7 @@ import lombok.extern.log4j.Log4j2;
 import nl.dtls.fairdatapoint.database.mongo.repository.ResourceDefinitionRepository;
 import nl.dtls.fairdatapoint.entity.resource.ResourceDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
@@ -112,7 +112,7 @@ public class OpenApiService {
         updateTags(resourceDefinitions);
     }
 
-    @EventListener(ContextRefreshedEvent.class)
+    @EventListener(ApplicationReadyEvent.class)
     public void init() {
         log.info("Initializing OpenAPI with generic paths");
         updateAllGenericPaths();


### PR DESCRIPTION
Fixes #687 by calling the update method at the end of app initialization, when all resource-definitions have been migrated..
