### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.10</version>
+        <version>3.5.12</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>nl.dtls</groupId>
@@ -56,7 +56,7 @@
         <spring-security-acl-mongodb.version>6.0.0</spring-security-acl-mongodb.version>
 
         <!-- Core -->
-        <springdoc-openapi-starter-webmvc-ui.version>2.8.15</springdoc-openapi-starter-webmvc-ui.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.8.16</springdoc-openapi-starter-webmvc-ui.version>
         <mongock-bom.version>5.5.1</mongock-bom.version>
         <rdf4j-runtime.version>5.2.2</rdf4j-runtime.version>
         <jjwt-api.version>0.13.0</jjwt-api.version>
@@ -67,9 +67,9 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <git-commit-id-maven-plugin.version>9.0.2</git-commit-id-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-        <checkstyle.version>13.0.0</checkstyle.version>
+        <checkstyle.version>13.3.0</checkstyle.version>
         <spring-javaformat-checkstyle.version>0.0.47</spring-javaformat-checkstyle.version>
-        <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- spring-boot-starter-parent 3.5.10 -> 3.5.12
- springdoc-openapi-starter-webmvc-ui 2.8.15 -> 2.8.16
- checkstyle 13.0.0 -> 13.3.0
- spotbugs-maven-plugin 4.9.3.0 -> 4.9.8.2
