### PR TITLE
Replace DTL by FAIR Data Team in license text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
                 <configuration>
                     <header>com/mycila/maven/plugin/license/templates/MIT.txt</header>
                     <properties>
-                        <owner>DTL</owner>
+                        <owner>FAIR Data Team</owner>
                     </properties>
                     <mapping>
                         <java>JAVADOC_STYLE</java>

--- a/src/main/java/org/fairdatateam/fairdatapoint/Application.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/Application.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/Profiles.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/Profiles.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/apikey/ApiKeyController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/apikey/ApiKeyController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/config/ConfigController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/config/ConfigController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/dashboard/DashboardController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/dashboard/DashboardController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/exception/ExceptionControllerAdvice.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/form/FormAutocompleteController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/form/FormAutocompleteController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexAdminController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexAdminController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexEntryController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexEntryController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexPingController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexPingController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexSettingsController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/index/IndexSettingsController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/label/LabelController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/label/LabelController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/membership/MembershipController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/membership/MembershipController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/metadata/GenericController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/metadata/GenericController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/metadata/GenericMemberController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/metadata/GenericMemberController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/metadata/GenericMetaController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/metadata/GenericMetaController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/profile/ProfileController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/profile/ProfileController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/reset/ResetController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/reset/ResetController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/resource/ResourceDefinitionController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/resource/ResourceDefinitionController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/schema/MetadataSchemaController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/schema/MetadataSchemaController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchSavedQueryController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchSavedQueryController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchSparqlController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchSparqlController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 // This code is mostly copied from rdf4j spring-boot-sparql-web, with some customizations:
 //
 // https://github.com/eclipse-rdf4j/rdf4j/blob/main/spring-components/spring-boot-sparql-web

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/settings/SettingsController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/settings/SettingsController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/token/TokenController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/token/TokenController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/user/UserController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/user/UserController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/converter/ErrorConverter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/converter/ErrorConverter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/converter/RdfConverter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/converter/RdfConverter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/apikey/ApiKeyDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/apikey/ApiKeyDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/auth/AuthDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/auth/AuthDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/auth/TokenDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/auth/TokenDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/common/BreadcrumbDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/common/BreadcrumbDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/config/BootstrapConfigDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/config/BootstrapConfigDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/dashboard/DashboardItemDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/dashboard/DashboardItemDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/error/ErrorDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/error/ErrorDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/form/FormAutocompleteItemDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/form/FormAutocompleteItemDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/form/FormAutocompleteRequestDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/form/FormAutocompleteRequestDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryDetailDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryDetailDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryInfoDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryInfoDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryStateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryStateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryUpdateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/entry/IndexEntryUpdateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/event/EventDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/event/EventDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/ping/PingDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/ping/PingDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsPingDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsPingDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsRetrievalDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsRetrievalDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsUpdateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/settings/IndexSettingsUpdateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/webhook/WebhookPayloadDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/index/webhook/WebhookPayloadDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/label/LabelDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/label/LabelDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/member/MemberCreateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/member/MemberCreateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/member/MemberDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/member/MemberDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/membership/MembershipDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/membership/MembershipDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/membership/MembershipPermissionDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/membership/MembershipPermissionDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaPathDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaPathDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaStateChangeDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaStateChangeDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaStateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/metadata/MetaStateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/reset/ResetDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/reset/ResetDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/resource/ResourceDefinitionChangeDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/resource/ResourceDefinitionChangeDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/resource/ResourceDefinitionDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/resource/ResourceDefinitionDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaChangeDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaChangeDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaDraftDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaDraftDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaPreviewRequestDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaPreviewRequestDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaReleaseDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaReleaseDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaRemoteDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaRemoteDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaRemoteState.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaRemoteState.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaUpdateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaUpdateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaVersionDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaVersionDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchFilterDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchFilterDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchFilterItemDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchFilterItemDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchQueryDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchQueryDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchQueryTemplateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchQueryTemplateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchQueryVariablesDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchQueryVariablesDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchResultDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchResultDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchSavedQueryChangeDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchSavedQueryChangeDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchSavedQueryDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/search/SearchSavedQueryDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsAutocompleteSourceDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsAutocompleteSourceDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsFormsAutocompleteDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsFormsAutocompleteDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsFormsDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsFormsDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsPingDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsPingDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsPingUpdateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsPingUpdateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsRepositoryDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsRepositoryDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsSearchDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsSearchDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsUpdateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/settings/SettingsUpdateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserChangeDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserChangeDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserCreateDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserCreateDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserPasswordDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserPasswordDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserProfileChangeDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserProfileChangeDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserSimpleDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/user/UserSimpleDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/filter/CORSFilter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/filter/CORSFilter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/filter/FilterConfigurer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/filter/FilterConfigurer.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/filter/JwtTokenFilter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/filter/JwtTokenFilter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/filter/LoggingFilter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/filter/LoggingFilter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/validator/DurationValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/validator/DurationValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/validator/IriValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/validator/IriValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/validator/SemVerValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/validator/SemVerValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/validator/ValidDuration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/validator/ValidDuration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/validator/ValidIri.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/validator/ValidIri.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/validator/ValidSemVer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/validator/ValidSemVer.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/AclConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/AclMethodSecurityConfiguration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/AclMethodSecurityConfiguration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/AsyncConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/AsyncConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/CacheConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/CacheConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ConverterConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ConverterConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/HttpClientConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/HttpClientConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/MetadataConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/MetadataConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/MongoConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/MongoConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/OpenApiConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/OpenApiConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/PasswordConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/PasswordConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/PropertyConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/PropertyConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/RepositoryConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/RepositoryConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/RepositoryMigrationConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/RepositoryMigrationConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/SecurityConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/WebConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/WebConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/WorkerConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/WorkerConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/InstanceProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/InstanceProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/OpenApiContactProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/OpenApiContactProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/OpenApiProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/OpenApiProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/PingProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/PingProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/RepositoryBasicProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/RepositoryBasicProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/RepositoryNativeProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/RepositoryNativeProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/properties/RepositoryProperties.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/properties/RepositoryProperties.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/common/migration/Migration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/common/migration/Migration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/MigrationRunner.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/MigrationRunner.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/acl/AclMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/acl/AclMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/apikey/ApiKeyMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/apikey/ApiKeyMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/apikey/data/ApiKeyFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/apikey/data/ApiKeyFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/index/entry/IndexEntryMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/index/entry/IndexEntryMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/index/entry/data/IndexEntryFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/index/entry/data/IndexEntryFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/index/event/EventMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/index/event/EventMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/membership/MembershipMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/membership/MembershipMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/membership/data/MembershipFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/membership/data/MembershipFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/metadata/MetadataMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/metadata/MetadataMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/metadata/data/MetadataFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/metadata/data/MetadataFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/resource/ResourceDefinitionMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/resource/ResourceDefinitionMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/resource/data/ResourceDefinitionFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/resource/data/ResourceDefinitionFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/schema/MetadataSchemaMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/schema/MetadataSchemaMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/schema/data/MetadataSchemaFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/schema/data/MetadataSchemaFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/search/SearchSavedQueryFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/search/SearchSavedQueryFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/settings/SettingsMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/settings/SettingsMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/settings/data/SettingsFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/settings/data/SettingsFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/user/UserMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/user/UserMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/user/data/UserFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/development/user/data/UserFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0001_Init.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0001_Init.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0002_CustomMetamodel.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0002_CustomMetamodel.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0003_ShapeDefinition.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0003_ShapeDefinition.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0004_ResourceDefinition.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0004_ResourceDefinition.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0005_UpdateShapeDefinition.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0005_UpdateShapeDefinition.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0006_ShapesSharing.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0006_ShapesSharing.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0007_RemoveMongobee.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0007_RemoveMongobee.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0008_ShapesInternalChange.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0008_ShapesInternalChange.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0009_ShapeTargetClasses.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0009_ShapeTargetClasses.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0010_FixShapeXsdPrefix.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0010_FixShapeXsdPrefix.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0011_ComplyFDPO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0011_ComplyFDPO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0012_MetadataSchemas.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0012_MetadataSchemas.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0013_ComplexSearch.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0013_ComplexSearch.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0014_FormsAutocomplete.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0014_FormsAutocomplete.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0015_FixMetadataVersion.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0015_FixMetadataVersion.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0016_FixSchemas.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0016_FixSchemas.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0017_FixSchemaDateTimes.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0017_FixSchemaDateTimes.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0018_IndexSettingsAutoPermit.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0018_IndexSettingsAutoPermit.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0019_SetIndexEntryPermitValue.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production/Migration_0019_SetIndexEntryPermitValue.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/ApiKeyRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/ApiKeyRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/EventRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/EventRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/IndexEntryRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/IndexEntryRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/IndexSettingsRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/IndexSettingsRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MembershipRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MembershipRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MetadataRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MetadataSchemaDraftRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MetadataSchemaDraftRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MetadataSchemaRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/MetadataSchemaRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/ResourceDefinitionRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/ResourceDefinitionRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/SearchSavedQueryRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/SearchSavedQueryRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/SettingsRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/SettingsRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/UserRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/UserRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/WebhookRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/mongo/repository/WebhookRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/RdfDevelopmentMigrationRunner.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/RdfDevelopmentMigrationRunner.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/RdfMetadataMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/RdfMetadataMigration.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/data/RdfMetadataFixtures.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/data/RdfMetadataFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/factory/MetadataFactory.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/factory/MetadataFactory.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/factory/MetadataFactoryImpl.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/development/metadata/factory/MetadataFactoryImpl.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0001_Init.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0001_Init.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0002_Metadata_Draft.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0002_Metadata_Draft.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0003_FDPO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0003_FDPO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0004_Cleanup_Index.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0004_Cleanup_Index.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0005_FixMetadataVersion.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/migration/production/Rdf_Migration_0005_FixMetadataVersion.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/catalog/CatalogMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/catalog/CatalogMetadataRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/catalog/CatalogMetadataRepositoryImpl.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/catalog/CatalogMetadataRepositoryImpl.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/common/AbstractMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/common/AbstractMetadataRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/common/MetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/common/MetadataRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/exception/MetadataRepositoryException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/exception/MetadataRepositoryException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/generic/GenericMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/generic/GenericMetadataRepository.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/generic/GenericMetadataRepositoryImpl.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/generic/GenericMetadataRepositoryImpl.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/apikey/ApiKey.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/apikey/ApiKey.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/FeatureDisabledException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/FeatureDisabledException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/ForbiddenException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/ForbiddenException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/MetadataSchemaImportException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/MetadataSchemaImportException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/RdfValidationException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/RdfValidationException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/ResourceNotFoundException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/ResourceNotFoundException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/UnauthorizedException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/UnauthorizedException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/ValidationException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/exception/ValidationException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/forms/RdfEntityCacheContainer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/forms/RdfEntityCacheContainer.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/forms/RdfEntitySourceType.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/forms/RdfEntitySourceType.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/IndexEntry.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/IndexEntry.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/IndexEntryPermit.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/IndexEntryPermit.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/IndexEntryState.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/IndexEntryState.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/RepositoryMetadata.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/entry/RepositoryMetadata.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/AdminTrigger.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/AdminTrigger.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/Event.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/Event.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/EventType.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/EventType.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/IncomingPing.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/IncomingPing.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/MetadataRetrieval.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/MetadataRetrieval.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/WebhookPing.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/WebhookPing.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/WebhookTrigger.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/event/WebhookTrigger.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/AbstractIndexException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/AbstractIndexException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/IncorrectPingFormatException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/IncorrectPingFormatException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/PingDeniedException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/PingDeniedException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/RateLimitException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/exception/RateLimitException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/Exchange.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/Exchange.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/ExchangeDirection.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/ExchangeDirection.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/ExchangeState.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/ExchangeState.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/Request.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/Request.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/Response.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/http/Response.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/settings/IndexSettings.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/settings/IndexSettings.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/settings/IndexSettingsPing.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/settings/IndexSettingsPing.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/settings/IndexSettingsRetrieval.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/settings/IndexSettingsRetrieval.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/webhook/Webhook.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/webhook/Webhook.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/index/webhook/WebhookEvent.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/index/webhook/WebhookEvent.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/membership/Membership.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/membership/Membership.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/membership/MembershipPermission.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/membership/MembershipPermission.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/AccessRights.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/AccessRights.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Agent.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Agent.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Authorization.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Authorization.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Identifier.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Identifier.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Metadata.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Metadata.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/MetadataGetter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/MetadataGetter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/MetadataSetter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/MetadataSetter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/MetadataState.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/MetadataState.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Metric.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/metadata/Metric.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinition.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinition.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionChild.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionChild.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionChildListView.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionChildListView.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionChildListViewMetadata.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionChildListViewMetadata.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionLink.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/resource/ResourceDefinitionLink.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/MetadataSchema.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/MetadataSchema.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/MetadataSchemaDraft.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/MetadataSchemaDraft.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/MetadataSchemaType.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/MetadataSchemaType.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/SemVer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/schema/SemVer.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchFilterCacheContainer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchFilterCacheContainer.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchFilterType.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchFilterType.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchFilterValue.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchFilterValue.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchResult.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchResult.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchResultRelation.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchResultRelation.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchSavedQuery.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchSavedQuery.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchSavedQueryType.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/search/SearchSavedQueryType.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/Settings.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/Settings.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsAutocompleteSource.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsAutocompleteSource.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsForms.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsForms.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsFormsAutocomplete.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsFormsAutocomplete.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsMetricsEntry.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsMetricsEntry.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsPing.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsPing.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsSearchFilter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsSearchFilter.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsSearchFilterItem.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/settings/SettingsSearchFilterItem.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/user/User.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/user/User.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/user/UserPermission.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/user/UserPermission.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/entity/user/UserRole.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/entity/user/UserRole.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/UtilityService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/UtilityService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/actuator/AppInfoContributor.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/actuator/AppInfoContributor.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/apikey/ApiKeyMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/apikey/ApiKeyMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/apikey/ApiKeyService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/apikey/ApiKeyService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/config/ConfigService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/config/ConfigService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/dashboard/DashboardService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/dashboard/DashboardService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/FormsAutocompleteCache.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/FormsAutocompleteCache.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/FormsAutocompleteService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/FormsAutocompleteService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/retrieval/RdfEntitiesNamespaceRetriever.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/retrieval/RdfEntitiesNamespaceRetriever.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/retrieval/RdfEntitiesRetriever.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/retrieval/RdfEntitiesRetriever.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/retrieval/RdfEntitiesSparqlRetriever.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/form/autocomplete/retrieval/RdfEntitiesSparqlRetriever.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/common/IndexFeatureAspect.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/common/IndexFeatureAspect.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/common/RequiredEnabledIndexFeature.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/common/RequiredEnabledIndexFeature.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/entry/IndexEntryMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/entry/IndexEntryMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/entry/IndexEntryService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/entry/IndexEntryService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/EventMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/EventMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/EventService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/EventService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/IncomingPingUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/IncomingPingUtils.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/MetadataRetrievalUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/MetadataRetrievalUtils.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/harvester/HarvesterService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/harvester/HarvesterService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/settings/IndexSettingsMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/settings/IndexSettingsMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/settings/IndexSettingsService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/settings/IndexSettingsService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookUtils.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/jwt/JwtService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/jwt/JwtService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/label/LabelService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/label/LabelService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/member/MemberMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/member/MemberMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/member/MemberService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/member/MemberService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/membership/MembershipMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/membership/MembershipMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/membership/MembershipService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/membership/MembershipService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/membership/PermissionService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/membership/PermissionService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/catalog/CatalogMetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/catalog/CatalogMetadataService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/common/AbstractMetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/common/AbstractMetadataService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/common/MetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/common/MetadataService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/exception/MetadataServiceException.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/exception/MetadataServiceException.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/factory/MetadataServiceFactory.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/factory/MetadataServiceFactory.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/generic/GenericMetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/generic/GenericMetadataService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/metric/MetricsMetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/metric/MetricsMetadataService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/state/MetadataStateService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/state/MetadataStateService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/validator/MetadataStateValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/validator/MetadataStateValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/validator/MetadataValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/validator/MetadataValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/openapi/OpenApiGenerator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/openapi/OpenApiGenerator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/openapi/OpenApiService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/openapi/OpenApiService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/openapi/OpenApiTagsUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/openapi/OpenApiTagsUtils.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/ping/PingService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/ping/PingService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/profile/ProfileService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/profile/ProfileService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/ShaclValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/ShaclValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/reset/FactoryDefaults.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/reset/FactoryDefaults.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/reset/ResetService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/reset/ResetService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionCache.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionCache.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionTargetClassesCache.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionTargetClassesCache.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaRetrievalUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaRetrievalUtils.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaShaclUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaShaclUtils.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchFilterCache.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchFilterCache.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/security/MongoAuthenticationService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/security/MongoAuthenticationService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/security/MongoUserDetailsService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/security/MongoUserDetailsService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/settings/SettingsCache.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/settings/SettingsCache.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/settings/SettingsMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/settings/SettingsMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/settings/SettingsService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/settings/SettingsService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/user/CurrentUserService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/user/CurrentUserService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/user/UserMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/user/UserMapper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/user/UserService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/user/UserService.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/user/UserValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/user/UserValidator.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/KnownUUIDs.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/KnownUUIDs.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/RdfIOUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/RdfIOUtil.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/RdfUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/RdfUtil.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/ResourceReader.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/ResourceReader.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/ThrowingFunction.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/ThrowingFunction.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/ValidationUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/ValidationUtil.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/ValueFactoryHelper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/ValueFactoryHelper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/DATACITE.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/DATACITE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/DCAT3.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/DCAT3.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/FDP.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/FDP.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/R3D.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/R3D.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/SIO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/vocabulary/SIO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/fairdatateam/fairdatapoint/database/mongo/migration/production/readme.md
+++ b/src/main/resources/org/fairdatateam/fairdatapoint/database/mongo/migration/production/readme.md
@@ -1,2 +1,2 @@
 The content of these SHACL files is copied into the `metadataSchema.definition` field when mongodb migrations are executed (by mongock).
-See corresponding migration classes in `src/main/java/nl/dtls/fairdatapoint/database/mongo/migration/production` for details.
+See corresponding migration classes in `src/main/java/org/fairdatateam/fairdatapoint/database/mongo/migration/production` for details.

--- a/src/test/java/org/fairdatateam/fairdatapoint/BaseIntegrationTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/BaseIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/WebIntegrationTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/WebIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/ActuatorInfoDTO.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/ActuatorInfoDTO.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/List_Info_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/List_Info_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/apikey/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/apikey/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/apikey/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/apikey/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/apikey/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/apikey/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/common/ForbiddenTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/common/ForbiddenTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/common/NotFoundTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/common/NotFoundTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/config/List_Bootstrap_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/config/List_Bootstrap_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/dashboard/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/dashboard/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/ContentNegotiationTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/ContentNegotiationTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/SecurityTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/SecurityTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/admin/List_TriggerAll_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/admin/List_TriggerAll_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/admin/List_Trigger_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/admin/List_Trigger_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/entry/List_All_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/entry/List_All_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/entry/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/entry/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/entry/List_Info_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/entry/List_Info_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/ping/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/ping/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/settings/List_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/settings/List_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/settings/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/settings/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/settings/List_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/index/settings/List_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/membership/Common.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/membership/Common.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/membership/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/membership/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/Common.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/Common.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_Expanded_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_Expanded_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_Page_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/Detail_Page_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/member/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/member/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/member/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/member/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/member/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/member/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/meta/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/meta/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/meta/List_State_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/meta/List_State_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_Expanded_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_Expanded_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_Page_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/Detail_Page_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/member/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/member/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/member/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/member/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/member/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/member/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/meta/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/meta/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/meta/List_State_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/dataset/meta/List_State_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_Expanded_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_Expanded_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/member/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/member/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/member/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/member/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/member/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/member/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/meta/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/meta/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/meta/List_State_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/distribution/meta/List_State_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_Expanded_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_Expanded_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_Page_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_Page_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/meta/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/meta/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/meta/List_State_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/meta/List_State_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/openapi/OpenApiDocs_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/openapi/OpenApiDocs_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/openapi/SwaggerUI_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/openapi/SwaggerUI_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/resource/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Common.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Common.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Content_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Content_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Import_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Import_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Public_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Public_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Version_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Version_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Version_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Version_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Version_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Version_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Versions_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Versions_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/Filters_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/Filters_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/query/saved/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/sparql/TestSearchSparqlController.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/search/sparql/TestSearchSparqlController.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package org.fairdatateam.fairdatapoint.acceptance.search.sparql;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/settings/List_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/settings/List_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/settings/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/settings/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/settings/List_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/settings/List_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/token/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/token/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Common.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Common.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Current_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Current_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_Current_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_Current_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_Current_Password_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_Current_Password_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_DELETE.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_DELETE.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_Password_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/Detail_Password_PUT.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/List_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/List_GET.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/user/List_POST.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/config/MetadataTestConfig.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/config/MetadataTestConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/config/RepositoryTestConfig.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/config/RepositoryTestConfig.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/catalog/CatalogMetadataRepositoryTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/catalog/CatalogMetadataRepositoryTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/common/MetadataRepositoryTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/common/MetadataRepositoryTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/generic/GenericMetadataRepositoryTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/generic/GenericMetadataRepositoryTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/entity/schema/SemVerTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/entity/schema/SemVerTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/index/harvester/HarvesterServiceTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/index/harvester/HarvesterServiceTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/metadata/catalog/CatalogMetadataServiceMockTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/metadata/catalog/CatalogMetadataServiceMockTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/metadata/generic/GenericMetadataServiceTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/metadata/generic/GenericMetadataServiceTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/metadata/metric/MetricsMetadataServiceTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/metadata/metric/MetricsMetadataServiceTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionCacheTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionCacheTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionValidatorTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/resource/ResourceDefinitionValidatorTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/utils/AuthHelper.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/utils/AuthHelper.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/utils/CustomPageImpl.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/utils/CustomPageImpl.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/utils/HttpUtilTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/utils/HttpUtilTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/utils/TestIndexEntryFixtures.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/utils/TestIndexEntryFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/fairdatateam/fairdatapoint/utils/TestRdfMetadataFixtures.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/utils/TestRdfMetadataFixtures.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2017 DTL
+ * Copyright © 2017 FAIR Data Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the owner in pom.xml and in license text for all files.
Year of inception does not change.