### PR TITLE
Collapse swagger docs by default

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,7 @@ springdoc:
   writer-with-default-pretty-printer: true
   swagger-ui:
     disable-swagger-default-url: true
+    doc-expansion: none
     operationsSorter: alpha
 
 server:


### PR DESCRIPTION
The swagger docs currently show all options expanded. 
This is very inconvenient because it requires a lot of scrolling and we don't get a good overview.
This PR collapses the docs by default, changing this

<img width="1853" height="932" alt="image" src="https://github.com/user-attachments/assets/3a7d57be-101c-4815-99b4-7074463c2735" />

into this

<img width="1854" height="933" alt="image" src="https://github.com/user-attachments/assets/a7d5831e-407e-4953-96a7-8319833a8105" />


