### PR TITLE
Hide details from saved-query user mapping

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,17 +2,21 @@
 
 ## Supported Versions
 
-We support the latest major and minor version with patch versions that fix vulnerabilities and critical bugs. For older versions, we highly recommend upgrading to the latest version. 
+We support the latest *major* and *minor* version with *patch* versions that fix vulnerabilities and critical bugs.
+For older versions, we highly recommend upgrading to the latest version. 
 
 | Version | Supported          |
 |---------| ------------------ |
-| 1.17.1  | :white_check_mark: |
-| < 1.17  | :x:                |
+| 1.19.x  | :white_check_mark: |
+| < 1.19  | :x:                |
 
 ## Current Recommendations
 
-* Use 1.17.0 with the newest dependencies (and no known vulnerabilities)
+* Always use the [latest release]. 
 
 ## Reporting a Vulnerability
 
-In case you encounter a vulnerability, please let us know via [GitHub issues](https://github.com/FAIRDataTeam/FAIRDataPoint/issues). If you need to share sensitive information, indicate that in the issue and we will provide a secured channel how you can privately send us such information.
+If you encounter a vulnerability, please create a [private security advisory] using the "Report a vulnerability" button at the top of this page.
+
+[private security advisory]: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability
+[latest release]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/latest

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryMapper.java
@@ -26,6 +26,7 @@ import org.fairdatateam.fairdatapoint.api.dto.search.SearchSavedQueryChangeDTO;
 import org.fairdatateam.fairdatapoint.api.dto.search.SearchSavedQueryDTO;
 import org.fairdatateam.fairdatapoint.api.dto.user.UserDTO;
 import org.fairdatateam.fairdatapoint.entity.search.SearchSavedQuery;
+import org.fairdatateam.fairdatapoint.entity.user.UserRole;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -33,9 +34,16 @@ import java.util.UUID;
 
 @Component
 public class SearchSavedQueryMapper {
-    public SearchSavedQueryDTO toDTO(
-            SearchSavedQuery query, UserDTO userDTO
-    ) {
+    public SearchSavedQueryDTO toDTO(SearchSavedQuery query) {
+        // anonymize the userDTO object as much as possible without breaking backward compatibility
+        // TODO: replace UserDTO object by simple userUuid string (breaking change, postpone until next major release)
+        final String hidden = "***";
+        final UserDTO userDTO = new UserDTO();
+        userDTO.setUuid(query.getUserUuid());
+        userDTO.setFirstName(String.format("%.8s", query.getUserUuid()));
+        userDTO.setLastName(hidden);
+        userDTO.setEmail(hidden);
+        userDTO.setRole(UserRole.USER);
         return SearchSavedQueryDTO.builder()
                 .uuid(query.getUuid())
                 .name(query.getName())

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/query/SearchSavedQueryService.java
@@ -37,11 +37,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 public class SearchSavedQueryService {
@@ -62,28 +59,19 @@ public class SearchSavedQueryService {
 
     public List<SearchSavedQueryDTO> getAll() {
         final Optional<User> optionalUser = currentUserService.getCurrentUser();
-        final Map<String, UserDTO> userMap =
-                userService
-                        .getUsers()
-                        .stream()
-                        .collect(Collectors.toMap(UserDTO::getUuid, Function.identity()));
         return repository
                 .findAll()
                 .parallelStream()
-                .filter(query -> canSeeQuery(optionalUser, query))
-                .map(query -> mapper.toDTO(query, userMap.get(query.getUserUuid())))
+                .filter(savedQuery -> canSeeQuery(optionalUser, savedQuery))
+                .map(savedQuery -> mapper.toDTO(savedQuery))
                 .toList();
     }
 
     public Optional<SearchSavedQueryDTO> getSingle(String uuid) {
         final Optional<User> optionalUser = currentUserService.getCurrentUser();
         return repository.findByUuid(uuid)
-                .filter(searchSavedQuery -> canSeeQuery(optionalUser, searchSavedQuery))
-                .map(searchSavedQuery -> {
-                    final UserDTO userDto =
-                            userService.getUserByUuid(searchSavedQuery.getUserUuid()).orElse(null);
-                    return mapper.toDTO(searchSavedQuery, userDto);
-                });
+                .filter(savedQuery -> canSeeQuery(optionalUser, savedQuery))
+                .map(savedQuery -> mapper.toDTO(savedQuery));
     }
 
     public boolean delete(String uuid) {
@@ -105,7 +93,7 @@ public class SearchSavedQueryService {
         final SearchSavedQuery searchSavedQuery = repository.save(
                 mapper.fromChangeDTO(reqDto, userDto)
         );
-        return mapper.toDTO(searchSavedQuery, userDto);
+        return mapper.toDTO(searchSavedQuery);
     }
 
     public Optional<SearchSavedQueryDTO> update(String uuid, SearchSavedQueryChangeDTO reqDto) {
@@ -121,15 +109,7 @@ public class SearchSavedQueryService {
         final SearchSavedQuery updatedQuery = repository.save(
                 mapper.fromChangeDTO(searchSavedQuery, reqDto)
         );
-        if (updatedQuery.getUserUuid() == null) {
-            return Optional.of(mapper.toDTO(updatedQuery, null));
-        }
-        return Optional.of(mapper.toDTO(
-                updatedQuery,
-                userService
-                        .getUserByUuid(updatedQuery.getUserUuid())
-                        .orElse(null))
-        );
+        return Optional.of(mapper.toDTO(updatedQuery));
     }
 
     private boolean canSeeQuery(Optional<User> optionalUser, SearchSavedQuery query) {


### PR DESCRIPTION
Hides unnecessary details from `SearchSavedQueryDTO.user` while preserving backward compatibility.