### PR TITLE
Refactor SearchService

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchSavedQueryController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/controller/search/SearchSavedQueryController.java
@@ -80,7 +80,7 @@ public class SearchSavedQueryController {
     ) throws ResourceNotFoundException, MetadataRepositoryException {
         final Optional<SearchSavedQueryDTO> oDto = searchSavedQueryService.getSingle(uuid);
         if (oDto.isPresent()) {
-            return ResponseEntity.ok(searchService.search(oDto.get()));
+            return ResponseEntity.ok(searchService.search(oDto.get().getVariables()));
         }
         else {
             throw new ResourceNotFoundException(format(NOT_FOUND_MSG, uuid));

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
@@ -48,7 +48,6 @@ public abstract class AbstractMetadataRepository implements MetadataRepository {
     private static final String MSG_ERROR_REMOVE_ALL = "Error remove all: ";
     private static final String MSG_ERROR_EXISTS = "Error check statement existence: ";
     private static final String MSG_ERROR_SAVE = "Error storing statements: ";
-    private static final String MSG_ERROR_SPARQL_LOAD = "Error reading %s.sparql file (error: %s)";
 
     private static final String FIELD_CHILD = "child";
     private static final String FIELD_TITLE = "title";

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchMapper.java
@@ -33,7 +33,6 @@ import org.fairdatateam.fairdatapoint.entity.settings.SettingsSearchFilterItem;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -46,7 +45,6 @@ public class SearchMapper {
     private static final String FIELD_REL_PRED = "relationPredicate";
     private static final String FIELD_TITLE = "title";
     private static final String FIELD_TYPE = "rdfType";
-    private static final String FRAGMENT_SUFFIX = "\n";
 
     public SearchQueryTemplateDTO toQueryTemplateDTO(String template) {
         return new SearchQueryTemplateDTO(template);
@@ -120,13 +118,5 @@ public class SearchMapper {
                 .label(value.getLabel())
                 .preset(false)
                 .build();
-    }
-
-    public Map<String, String> toSubstitutions(SearchQueryVariablesDTO reqDto) {
-        return Map.of(
-                "prefixes", reqDto.getPrefixes() + FRAGMENT_SUFFIX,
-                "graphPattern", reqDto.getGraphPattern() + FRAGMENT_SUFFIX,
-                "ordering", reqDto.getOrdering() + FRAGMENT_SUFFIX
-        );
     }
 }

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -208,12 +208,25 @@ public class SearchService {
         }
     }
 
-    private String composeQuery(SearchQueryVariablesDTO reqDto) {
-        final StrSubstitutor substitutor =
-                new StrSubstitutor(searchMapper.toSubstitutions(reqDto), "{{", "}}");
+    /**
+     * Renders a SPARQL query string based on the restricted query defined in <code>QUERY_TEMPLATE</code> and user input
+     * @param queryVariables User input to be used as template context
+     * @return Full SPARQL query string
+     */
+    private String composeQuery(SearchQueryVariablesDTO queryVariables) {
+        final Map<String, String> templateContext = Map.of(
+                "prefixes", queryVariables.getPrefixes(),
+                "graphPattern", queryVariables.getGraphPattern(),
+                "ordering", queryVariables.getOrdering()
+        );
+        final StrSubstitutor substitutor = new StrSubstitutor(templateContext, "{{", "}}");
         return substitutor.replace(QUERY_TEMPLATE);
     }
 
+    /**
+     * Loads a query template string from file
+     * @return SPARQL query template string
+     */
     private static String loadSparqlQueryTemplate() {
         try {
             final Optional<URL> fileURL = Optional.ofNullable(SearchService.class.getResource(QUERY_TEMPLATE_NAME));

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -22,8 +22,6 @@
  */
 package org.fairdatateam.fairdatapoint.service.search;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
 import org.fairdatateam.fairdatapoint.api.dto.search.*;
 import org.fairdatateam.fairdatapoint.database.rdf.repository.MetadataRepositoryException;
 import org.fairdatateam.fairdatapoint.database.rdf.repository.GenericMetadataRepository;
@@ -46,7 +44,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -66,7 +63,7 @@ public class SearchService {
     private static final String FIND_OBJECT_FOR_PREDICATE = "/sparql/findObjectsForPredicate.sparql";
     private static final String QUERY_TEMPLATE_NAME = "/sparql/queryTemplate.sparql";
 
-    private static final String QUERY_TEMPLATE = loadSparqlQueryTemplate();
+    private static String QUERY_TEMPLATE;
 
     private final GenericMetadataRepository metadataRepository;
 
@@ -98,6 +95,7 @@ public class SearchService {
         this.searchMapper = searchMapper;
         this.searchFilterCache = searchFilterCache;
         this.settingsService = settingsService;
+        QUERY_TEMPLATE = loadSparqlQueryTemplate();
     }
 
     /**
@@ -243,7 +241,7 @@ public class SearchService {
      * Loads a query template string from file
      * @return SPARQL query template string
      */
-    private static String loadSparqlQueryTemplate() {
+    private String loadSparqlQueryTemplate() {
         try {
             final Optional<URL> fileURL = Optional.ofNullable(SearchService.class.getResource(QUERY_TEMPLATE_NAME));
             return Resources.toString(fileURL.orElseThrow(), Charsets.UTF_8);

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -88,12 +88,6 @@ public class SearchService {
     @Qualifier("persistentUrl")
     private String persistentUrl;
 
-    public List<SearchResultDTO> search(
-            SearchSavedQueryDTO searchSavedQueryDTO
-    ) throws MetadataRepositoryException {
-        return search(searchSavedQueryDTO.getVariables());
-    }
-
     public List<SearchResultDTO> search(SearchQueryDTO reqDto) throws MetadataRepositoryException {
         final List<SearchResult> results = findByLiteral(l(reqDto.getQuery()));
         return processSearchResults(results);

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -42,7 +42,6 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -69,24 +68,37 @@ public class SearchService {
 
     private static final String QUERY_TEMPLATE = loadSparqlQueryTemplate();
 
-    @Autowired
-    private GenericMetadataRepository metadataRepository;
+    private final GenericMetadataRepository metadataRepository;
 
-    @Autowired
-    private MetadataStateService metadataStateService;
+    private final MetadataStateService metadataStateService;
 
-    @Autowired
-    private SearchMapper searchMapper;
+    private final SearchMapper searchMapper;
 
-    @Autowired
-    private SettingsService settingsService;
+    private final SettingsService settingsService;
 
-    @Autowired
-    private SearchFilterCache searchFilterCache;
+    private final SearchFilterCache searchFilterCache;
 
-    @Autowired
     @Qualifier("persistentUrl")
     private String persistentUrl;
+
+    /**
+     * Constructor (autowired)
+     */
+    public SearchService(
+            GenericMetadataRepository metadataRepository,
+            MetadataStateService metadataStateService,
+            String persistentUrl,
+            SearchMapper searchMapper,
+            SearchFilterCache searchFilterCache,
+            SettingsService settingsService
+    ) {
+        this.metadataRepository = metadataRepository;
+        this.metadataStateService = metadataStateService;
+        this.persistentUrl = persistentUrl;
+        this.searchMapper = searchMapper;
+        this.searchFilterCache = searchFilterCache;
+        this.settingsService = settingsService;
+    }
 
     /**
      * Performs a predefined SPARQL query looking for a string literal

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -88,16 +88,26 @@ public class SearchService {
     @Qualifier("persistentUrl")
     private String persistentUrl;
 
-    public List<SearchResultDTO> search(SearchQueryDTO reqDto) throws MetadataRepositoryException {
-        final List<SearchResult> results = findByLiteral(l(reqDto.getQuery()));
+    /**
+     * Performs a predefined SPARQL query looking for a string literal
+     * @param simpleQuery Object containing a search string literal
+     * @return List of search result objects
+     */
+    public List<SearchResultDTO> search(SearchQueryDTO simpleQuery) throws MetadataRepositoryException {
+        final List<SearchResult> results = findByLiteral(l(simpleQuery.getQuery()));
         return processSearchResults(results);
     }
 
+    /**
+     * Evaluates restricted SPARQL query as defined in query template
+     * @param queryVariables User input as context for query template
+     * @return List of search result objects
+     */
     public List<SearchResultDTO> search(
-            SearchQueryVariablesDTO reqDto
+            SearchQueryVariablesDTO queryVariables
     ) throws MetadataRepositoryException, MalformedQueryException {
         // Compose query
-        final String query = composeQuery(reqDto);
+        final String query = composeQuery(queryVariables);
         // Verify query
         final SPARQLParser parser = new SPARQLParser();
         parser.parseQuery(query, persistentUrl);

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -43,13 +43,12 @@ import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static org.fairdatateam.fairdatapoint.util.ResourceReader.loadResource;
 import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.i;
 import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.l;
 
@@ -95,7 +94,7 @@ public class SearchService {
         this.searchMapper = searchMapper;
         this.searchFilterCache = searchFilterCache;
         this.settingsService = settingsService;
-        queryTemplate = loadSparqlQueryTemplate();
+        queryTemplate = loadResource(QUERY_TEMPLATE_NAME);
     }
 
     /**
@@ -235,21 +234,6 @@ public class SearchService {
         );
         final StrSubstitutor substitutor = new StrSubstitutor(templateContext, "{{", "}}");
         return substitutor.replace(queryTemplate);
-    }
-
-    /**
-     * Loads a query template string from file
-     * @return SPARQL query template string
-     */
-    private String loadSparqlQueryTemplate() {
-        try {
-            return metadataRepository.loadSparqlQuery(QUERY_TEMPLATE_NAME, SearchService.class);
-        }
-        catch (IOException | NoSuchElementException exception) {
-            throw new RuntimeException(
-                    format("Cannot load SPARQL template for search: %s", exception.getMessage())
-            );
-        }
     }
 
     public List<SearchResult> findByLiteral(Literal query) throws MetadataRepositoryException {

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -247,8 +247,7 @@ public class SearchService {
         }
         catch (IOException | NoSuchElementException exception) {
             throw new RuntimeException(
-                    format("Cannot load SPARQL template for search: %s",
-                            exception.getMessage())
+                    format("Cannot load SPARQL template for search: %s", exception.getMessage())
             );
         }
     }

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -79,7 +79,7 @@ public class SearchService {
     private final SearchFilterCache searchFilterCache;
 
     @Qualifier("persistentUrl")
-    private String persistentUrl;
+    private final String persistentUrl;
 
     /**
      * Constructor (autowired)

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -63,7 +63,7 @@ public class SearchService {
     private static final String FIND_OBJECT_FOR_PREDICATE = "/sparql/findObjectsForPredicate.sparql";
     private static final String QUERY_TEMPLATE_NAME = "/sparql/queryTemplate.sparql";
 
-    private static String QUERY_TEMPLATE;
+    private static String queryTemplate;
 
     private final GenericMetadataRepository metadataRepository;
 
@@ -95,7 +95,7 @@ public class SearchService {
         this.searchMapper = searchMapper;
         this.searchFilterCache = searchFilterCache;
         this.settingsService = settingsService;
-        QUERY_TEMPLATE = loadSparqlQueryTemplate();
+        queryTemplate = loadSparqlQueryTemplate();
     }
 
     /**
@@ -127,7 +127,7 @@ public class SearchService {
     }
 
     public SearchQueryTemplateDTO getSearchQueryTemplate() {
-        return searchMapper.toQueryTemplateDTO(QUERY_TEMPLATE);
+        return searchMapper.toQueryTemplateDTO(queryTemplate);
     }
 
     public List<SearchFilterDTO> getSearchFilters() {
@@ -234,7 +234,7 @@ public class SearchService {
                 "ordering", queryVariables.getOrdering()
         );
         final StrSubstitutor substitutor = new StrSubstitutor(templateContext, "{{", "}}");
-        return substitutor.replace(QUERY_TEMPLATE);
+        return substitutor.replace(queryTemplate);
     }
 
     /**

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -243,8 +243,7 @@ public class SearchService {
      */
     private String loadSparqlQueryTemplate() {
         try {
-            final Optional<URL> fileURL = Optional.ofNullable(SearchService.class.getResource(QUERY_TEMPLATE_NAME));
-            return Resources.toString(fileURL.orElseThrow(), Charsets.UTF_8);
+            return metadataRepository.loadSparqlQuery(QUERY_TEMPLATE_NAME, SearchService.class);
         }
         catch (IOException | NoSuchElementException exception) {
             throw new RuntimeException(


### PR DESCRIPTION

- `AbstractMetadataRepository.loadSparqlQuery` is now public and handles `null` values for `fileUrl`
- `SearchService` now uses constructor autowiring
- reuses `ResourceLoader.loadResource`, so `loadSparqlQueryTemplate` is no longer needed
- now loads the query template in the constructor, renamed `QUERY_TEMPLATE` to `queryTemplate` accordingly
- the overloaded `search` method for string literals has been removed, and we now simply pass the correct argument into the other `search` method
- `SearchMapper.toSubstitutions` has been moved into `SearchService.composeQuery` to improve cohesion
