### PR TITLE
Clean up MetadataRepository interface and implementations

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
@@ -22,8 +22,7 @@
  */
 package org.fairdatateam.fairdatapoint.database.rdf.repository;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.*;
@@ -34,13 +33,9 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static java.lang.String.format;
+import static org.fairdatateam.fairdatapoint.util.ResourceReader.loadResource;
 
 @Slf4j
 public abstract class AbstractMetadataRepository implements MetadataRepository {
@@ -78,24 +73,16 @@ public abstract class AbstractMetadataRepository implements MetadataRepository {
         }
     }
 
-    public Map<String, String> findChildTitles(IRI parent, IRI relation)
-            throws MetadataRepositoryException {
+    public Map<String, String> findChildTitles(IRI parent, IRI relation) throws MetadataRepositoryException {
         final Map<String, String> titles = new HashMap<>();
-
-        final List<BindingSet> results = runSparqlQuery(
-                FIND_CHILD_TITLES,
-                AbstractMetadataRepository.class,
-                Map.of(
-                        "parent", parent,
-                        "relation", relation
-                ));
-
+        final List<BindingSet> results = runSparqlQueryFromFile(
+                FIND_CHILD_TITLES, Map.of("parent", parent, "relation", relation)
+        );
         for (var result : results) {
             final String childUri = result.getValue(FIELD_CHILD).stringValue();
             final String title = result.getValue(FIELD_TITLE).stringValue();
             titles.put(childUri, title);
         }
-
         return titles;
     }
 
@@ -141,36 +128,39 @@ public abstract class AbstractMetadataRepository implements MetadataRepository {
         }
     }
 
+    /**
+     * Evaluate a full SPARQL query string. The <code>bindings</code> argument may be used to assign (bind) values
+     * to any of the SPARQL query variables.
+     * @param queryString string containing a SPARQL query
+     * @param bindings map of values to be assigned to SPARQL query variables (or null if there are none)
+     * @return list of query results
+     */
     public List<BindingSet> runSparqlQuery(
-            String queryName, Class<?> repositoryType, Map<String, Value> bindings
+            String queryString, @Nullable Map<String, Value> bindings
     ) throws MetadataRepositoryException {
         try (RepositoryConnection conn = repository.getConnection()) {
-            final String queryString = loadSparqlQuery(queryName, repositoryType);
             final TupleQuery query = conn.prepareTupleQuery(queryString);
-            bindings.forEach(query::setBinding);
+            if (bindings != null) {
+                // assign values to variables defined in the sparql query
+                bindings.forEach(query::setBinding);
+            }
             return QueryResults.asList(query.evaluate());
         }
         catch (RepositoryException exception) {
             throw new MetadataRepositoryException(MSG_ERROR_URI + exception.getMessage());
         }
-        catch (IOException exception) {
-            throw new MetadataRepositoryException(format(MSG_ERROR_SPARQL_LOAD, queryName,
-                    exception.getMessage()));
-        }
     }
 
-    public List<BindingSet> runSparqlQuery(String queryString) throws MetadataRepositoryException {
-        try (RepositoryConnection conn = repository.getConnection()) {
-            final TupleQuery query = conn.prepareTupleQuery(queryString);
-            return query.evaluate().stream().toList();
-        }
-        catch (RepositoryException exception) {
-            throw new MetadataRepositoryException(MSG_ERROR_URI + exception.getMessage());
-        }
-    }
-
-    protected String loadSparqlQuery(String queryName, Class repositoryType) throws IOException {
-        final URL fileURL = repositoryType.getResource(queryName);
-        return Resources.toString(fileURL, Charsets.UTF_8);
+    /**
+     * Evaluate SPARQL query stored in a file
+     * @param queryFilePath path to SPARQL query file
+     * @param bindings map of values to be assigned to SPARQL query variables (or null if there are none)
+     * @return list of query results
+     */
+    public List<BindingSet> runSparqlQueryFromFile(
+            String queryFilePath, @Nullable Map<String, Value> bindings
+    ) throws MetadataRepositoryException {
+        final String queryString = loadResource(queryFilePath);
+        return runSparqlQuery(queryString, bindings);
     }
 }

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
@@ -81,22 +81,6 @@ public abstract class AbstractMetadataRepository implements MetadataRepository {
         this.repository = repository;
     }
 
-    protected Repository getRepository() {
-        return repository;
-    }
-
-    public List<Resource> findResources() throws MetadataRepositoryException {
-        try (RepositoryConnection conn = repository.getConnection()) {
-
-            return Iterations.asList(
-                    conn.getContextIDs()
-            );
-        }
-        catch (RepositoryException exception) {
-            throw new MetadataRepositoryException(MSG_ERROR_RESOURCE + exception.getMessage());
-        }
-    }
-
     public List<Statement> find(IRI context) throws MetadataRepositoryException {
         try (RepositoryConnection conn = repository.getConnection()) {
             return Iterations.asList(

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/AbstractMetadataRepository.java
@@ -25,9 +25,6 @@ package org.fairdatateam.fairdatapoint.database.rdf.repository;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import lombok.extern.slf4j.Slf4j;
-import org.fairdatateam.fairdatapoint.entity.search.SearchFilterValue;
-import org.fairdatateam.fairdatapoint.entity.search.SearchResult;
-import org.fairdatateam.fairdatapoint.entity.search.SearchResultRelation;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -42,17 +39,13 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 
 @Slf4j
 public abstract class AbstractMetadataRepository implements MetadataRepository {
 
-    private static final String FIND_ENTITY_BY_LITERAL = "/sparql/findEntityByLiteral.sparql";
     private static final String FIND_CHILD_TITLES = "/sparql/findChildTitles.sparql";
-    private static final String FIND_OBJECT_FOR_PREDICATE = "/sparql/findObjectsForPredicate.sparql";
 
     private static final String MSG_ERROR_RESOURCE = "Error retrieving resource: ";
     private static final String MSG_ERROR_URI = "Error retrieving repository URI: ";
@@ -62,15 +55,8 @@ public abstract class AbstractMetadataRepository implements MetadataRepository {
     private static final String MSG_ERROR_SAVE = "Error storing statements: ";
     private static final String MSG_ERROR_SPARQL_LOAD = "Error reading %s.sparql file (error: %s)";
 
-    private static final String FIELD_VALUE = "value";
-    private static final String FIELD_LABEL = "label";
     private static final String FIELD_CHILD = "child";
     private static final String FIELD_TITLE = "title";
-    private static final String FIELD_ENTITY = "entity";
-    private static final String FIELD_TYPE = "rdfType";
-    private static final String FIELD_DESCRIPTION = "description";
-    private static final String FIELD_REL_PRED = "relationPredicate";
-    private static final String FIELD_REL_OBJ = "relationObject";
 
     private final Repository repository;
 
@@ -90,63 +76,6 @@ public abstract class AbstractMetadataRepository implements MetadataRepository {
         catch (RepositoryException exception) {
             throw new MetadataRepositoryException(MSG_ERROR_RESOURCE + exception.getMessage());
         }
-    }
-
-    public List<SearchResult> findByLiteral(Literal query) throws MetadataRepositoryException {
-        return runSparqlQuery(
-                FIND_ENTITY_BY_LITERAL,
-                AbstractMetadataRepository.class,
-                Map.of("query", query)
-        )
-                .stream()
-                .map(item -> toSearchResult(item, true))
-                .toList();
-    }
-
-    public List<SearchResult> findBySparqlQuery(String query) throws MetadataRepositoryException {
-        return runSparqlQuery(query)
-                .stream()
-                .map(item -> toSearchResult(item, false))
-                .toList();
-    }
-
-    private SearchResult toSearchResult(BindingSet item, boolean withRelation) {
-        SearchResultRelation relation = null;
-        if (withRelation) {
-            relation = new SearchResultRelation(
-                    item.getValue(FIELD_REL_PRED).stringValue(),
-                    item.getValue(FIELD_REL_OBJ).stringValue()
-            );
-        }
-        return new SearchResult(
-                item.getValue(FIELD_ENTITY).stringValue(),
-                item.getValue(FIELD_TYPE).stringValue(),
-                item.getValue(FIELD_TITLE).stringValue(),
-                ofNullable(item.getValue(FIELD_DESCRIPTION)).map(Value::stringValue).orElse(""),
-                relation
-        );
-    }
-
-    public List<SearchFilterValue> findByFilterPredicate(IRI predicateUri)
-            throws MetadataRepositoryException {
-        final Map<String, String> values = new HashMap<>();
-        runSparqlQuery(
-                FIND_OBJECT_FOR_PREDICATE,
-                AbstractMetadataRepository.class,
-                Map.of("predicate", predicateUri)
-        ).forEach(entry -> {
-            values.put(
-                    entry.getValue(FIELD_VALUE).stringValue(),
-                    Optional.ofNullable(entry.getValue(FIELD_LABEL))
-                            .map(Value::stringValue)
-                            .orElse(null)
-            );
-        });
-        return values
-                .entrySet()
-                .stream()
-                .map(entry -> new SearchFilterValue(entry.getKey(), entry.getValue()))
-                .toList();
     }
 
     public Map<String, String> findChildTitles(IRI parent, IRI relation)

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/CatalogMetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/CatalogMetadataRepository.java
@@ -61,8 +61,7 @@ public class CatalogMetadataRepository extends AbstractMetadataRepository {
         if (result != null) {
             return result;
         }
-        result = runSparqlQuery(GET_DATASET_THEMES_FOR_CATALOG, CatalogMetadataRepository.class, Map.of(
-                "catalog", uri))
+        result = runSparqlQueryFromFile(GET_DATASET_THEMES_FOR_CATALOG, Map.of("catalog", uri))
                 .stream()
                 .map(item -> i(item.getValue("theme").stringValue()))
                 .collect(Collectors.toList());

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepository.java
@@ -37,8 +37,6 @@ import java.util.Map;
 
 public interface MetadataRepository {
 
-    List<Resource> findResources() throws MetadataRepositoryException;
-
     List<Statement> find(IRI context) throws MetadataRepositoryException;
 
     List<SearchResult> findByLiteral(Literal query) throws MetadataRepositoryException;

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepository.java
@@ -27,8 +27,6 @@
  */
 package org.fairdatateam.fairdatapoint.database.rdf.repository;
 
-import org.fairdatateam.fairdatapoint.entity.search.SearchFilterValue;
-import org.fairdatateam.fairdatapoint.entity.search.SearchResult;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.query.BindingSet;
 
@@ -38,13 +36,6 @@ import java.util.Map;
 public interface MetadataRepository {
 
     List<Statement> find(IRI context) throws MetadataRepositoryException;
-
-    List<SearchResult> findByLiteral(Literal query) throws MetadataRepositoryException;
-
-    List<SearchResult> findBySparqlQuery(String query) throws MetadataRepositoryException;
-
-    List<SearchFilterValue> findByFilterPredicate(IRI predicateUri)
-            throws MetadataRepositoryException;
 
     Map<String, String> findChildTitles(IRI parent, IRI relation)
             throws MetadataRepositoryException;

--- a/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepository.java
@@ -52,7 +52,5 @@ public interface MetadataRepository {
     void removeStatement(Resource subject, IRI predicate, Value object, IRI context)
             throws MetadataRepositoryException;
 
-    List<BindingSet> runSparqlQuery(
-            String queryName, Class<?> repositoryType, Map<String, Value> bindings
-    ) throws MetadataRepositoryException;
+    List<BindingSet> runSparqlQuery(String queryString, Map<String, Value> bindings) throws MetadataRepositoryException;
 }

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchMapper.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchMapper.java
@@ -22,9 +22,12 @@
  */
 package org.fairdatateam.fairdatapoint.service.search;
 
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
 import org.fairdatateam.fairdatapoint.api.dto.search.*;
 import org.fairdatateam.fairdatapoint.entity.search.SearchFilterValue;
 import org.fairdatateam.fairdatapoint.entity.search.SearchResult;
+import org.fairdatateam.fairdatapoint.entity.search.SearchResultRelation;
 import org.fairdatateam.fairdatapoint.entity.settings.SettingsSearchFilter;
 import org.fairdatateam.fairdatapoint.entity.settings.SettingsSearchFilterItem;
 import org.springframework.stereotype.Component;
@@ -32,10 +35,17 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 @Component
 public class SearchMapper {
 
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_ENTITY = "entity";
+    private static final String FIELD_REL_OBJ = "relationObject";
+    private static final String FIELD_REL_PRED = "relationPredicate";
+    private static final String FIELD_TITLE = "title";
+    private static final String FIELD_TYPE = "rdfType";
     private static final String FRAGMENT_SUFFIX = "\n";
 
     public SearchQueryTemplateDTO toQueryTemplateDTO(String template) {
@@ -58,6 +68,23 @@ public class SearchMapper {
                         .filter(Objects::nonNull)
                         .distinct()
                         .toList()
+        );
+    }
+
+    public SearchResult toSearchResult(BindingSet item, boolean withRelation) {
+        SearchResultRelation relation = null;
+        if (withRelation) {
+            relation = new SearchResultRelation(
+                    item.getValue(FIELD_REL_PRED).stringValue(),
+                    item.getValue(FIELD_REL_OBJ).stringValue()
+            );
+        }
+        return new SearchResult(
+                item.getValue(FIELD_ENTITY).stringValue(),
+                item.getValue(FIELD_TYPE).stringValue(),
+                item.getValue(FIELD_TITLE).stringValue(),
+                Optional.ofNullable(item.getValue(FIELD_DESCRIPTION)).map(Value::stringValue).orElse(""),
+                relation
         );
     }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -25,6 +25,7 @@ package org.fairdatateam.fairdatapoint.service.search;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.fairdatateam.fairdatapoint.api.dto.search.*;
+import org.fairdatateam.fairdatapoint.database.rdf.repository.AbstractMetadataRepository;
 import org.fairdatateam.fairdatapoint.database.rdf.repository.MetadataRepositoryException;
 import org.fairdatateam.fairdatapoint.database.rdf.repository.GenericMetadataRepository;
 import org.fairdatateam.fairdatapoint.entity.exception.ResourceNotFoundException;
@@ -38,6 +39,8 @@ import org.fairdatateam.fairdatapoint.service.metadata.state.MetadataStateServic
 import org.fairdatateam.fairdatapoint.service.settings.SettingsService;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +61,11 @@ import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.l;
 @Service
 public class SearchService {
 
+    private static final String FIELD_VALUE = "value";
+    private static final String FIELD_LABEL = "label";
+
+    private static final String FIND_ENTITY_BY_LITERAL = "/sparql/findEntityByLiteral.sparql";
+    private static final String FIND_OBJECT_FOR_PREDICATE = "/sparql/findObjectsForPredicate.sparql";
     private static final String QUERY_TEMPLATE_NAME = "/sparql/queryTemplate.sparql";
 
     private static final String QUERY_TEMPLATE = loadSparqlQueryTemplate();
@@ -88,7 +96,7 @@ public class SearchService {
     }
 
     public List<SearchResultDTO> search(SearchQueryDTO reqDto) throws MetadataRepositoryException {
-        final List<SearchResult> results = metadataRepository.findByLiteral(l(reqDto.getQuery()));
+        final List<SearchResult> results = findByLiteral(l(reqDto.getQuery()));
         return processSearchResults(results);
     }
 
@@ -101,7 +109,7 @@ public class SearchService {
         final SPARQLParser parser = new SPARQLParser();
         parser.parseQuery(query, persistentUrl);
         // Get and process results for query
-        final List<SearchResult> results = metadataRepository.findBySparqlQuery(query);
+        final List<SearchResult> results = findBySparqlQuery(query);
         return processSearchResults(results);
     }
 
@@ -157,8 +165,7 @@ public class SearchService {
             return cacheContainer.getValues();
         }
         try {
-            final List<SearchFilterValue> result =
-                    metadataRepository.findByFilterPredicate(i(predicate));
+            final List<SearchFilterValue> result = findByFilterPredicate(i(predicate));
             searchFilterCache.setFilter(predicate, new SearchFilterCacheContainer(result));
             return result;
         }
@@ -219,5 +226,40 @@ public class SearchService {
                             exception.getMessage())
             );
         }
+    }
+
+    public List<SearchResult> findByLiteral(Literal query) throws MetadataRepositoryException {
+        return metadataRepository
+                .runSparqlQuery(FIND_ENTITY_BY_LITERAL, AbstractMetadataRepository.class, Map.of("query", query))
+                .stream()
+                .map(item -> searchMapper.toSearchResult(item, true))
+                .toList();
+    }
+
+    public List<SearchResult> findBySparqlQuery(String query) throws MetadataRepositoryException {
+        return metadataRepository
+                .runSparqlQuery(query)
+                .stream()
+                .map(item -> searchMapper.toSearchResult(item, false))
+                .toList();
+    }
+
+    public List<SearchFilterValue> findByFilterPredicate(IRI predicateUri) throws MetadataRepositoryException {
+        final Map<String, String> values = new HashMap<>();
+        metadataRepository.runSparqlQuery(
+                FIND_OBJECT_FOR_PREDICATE,
+                AbstractMetadataRepository.class,
+                Map.of("predicate", predicateUri)
+        ).forEach(entry -> {
+            values.put(
+                    entry.getValue(FIELD_VALUE).stringValue(),
+                    Optional.ofNullable(entry.getValue(FIELD_LABEL)).map(Value::stringValue).orElse(null)
+            );
+        });
+        return values
+                .entrySet()
+                .stream()
+                .map(entry -> new SearchFilterValue(entry.getKey(), entry.getValue()))
+                .toList();
     }
 }

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -25,7 +25,6 @@ package org.fairdatateam.fairdatapoint.service.search;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.fairdatateam.fairdatapoint.api.dto.search.*;
-import org.fairdatateam.fairdatapoint.database.rdf.repository.AbstractMetadataRepository;
 import org.fairdatateam.fairdatapoint.database.rdf.repository.MetadataRepositoryException;
 import org.fairdatateam.fairdatapoint.database.rdf.repository.GenericMetadataRepository;
 import org.fairdatateam.fairdatapoint.entity.exception.ResourceNotFoundException;
@@ -229,8 +228,7 @@ public class SearchService {
     }
 
     public List<SearchResult> findByLiteral(Literal query) throws MetadataRepositoryException {
-        return metadataRepository
-                .runSparqlQuery(FIND_ENTITY_BY_LITERAL, AbstractMetadataRepository.class, Map.of("query", query))
+        return metadataRepository.runSparqlQueryFromFile(FIND_ENTITY_BY_LITERAL, Map.of("query", query))
                 .stream()
                 .map(item -> searchMapper.toSearchResult(item, true))
                 .toList();
@@ -238,7 +236,7 @@ public class SearchService {
 
     public List<SearchResult> findBySparqlQuery(String query) throws MetadataRepositoryException {
         return metadataRepository
-                .runSparqlQuery(query)
+                .runSparqlQuery(query, null)
                 .stream()
                 .map(item -> searchMapper.toSearchResult(item, false))
                 .toList();
@@ -246,9 +244,8 @@ public class SearchService {
 
     public List<SearchFilterValue> findByFilterPredicate(IRI predicateUri) throws MetadataRepositoryException {
         final Map<String, String> values = new HashMap<>();
-        metadataRepository.runSparqlQuery(
+        metadataRepository.runSparqlQueryFromFile(
                 FIND_OBJECT_FOR_PREDICATE,
-                AbstractMetadataRepository.class,
                 Map.of("predicate", predicateUri)
         ).forEach(entry -> {
             values.put(

--- a/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/CatalogMetadataRepositoryTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/CatalogMetadataRepositoryTest.java
@@ -82,7 +82,7 @@ public class CatalogMetadataRepositoryTest {
         catalogMetadataRepository.getDatasetThemesForCatalog(catalogUri);
 
         // THEN:
-        verify(catalogMetadataRepository, never()).runSparqlQuery(any(), any(), any());
+        verify(catalogMetadataRepository, never()).runSparqlQueryFromFile(any(), any());
     }
 
     @Test
@@ -98,7 +98,7 @@ public class CatalogMetadataRepositoryTest {
         catalogMetadataRepository.getDatasetThemesForCatalog(catalogUri);
 
         // THEN:
-        verify(catalogMetadataRepository, times(1)).runSparqlQuery(any(), any(), any());
+        verify(catalogMetadataRepository, times(1)).runSparqlQueryFromFile(any(), any());
     }
 
 }

--- a/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepositoryTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/database/rdf/repository/MetadataRepositoryTest.java
@@ -27,11 +27,8 @@
  */
 package org.fairdatateam.fairdatapoint.database.rdf.repository;
 
-import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
 import org.fairdatateam.fairdatapoint.WebIntegrationTest;
-import org.fairdatateam.fairdatapoint.entity.search.SearchFilterValue;
-import org.fairdatateam.fairdatapoint.entity.search.SearchResult;
 import org.fairdatateam.fairdatapoint.utils.TestRdfMetadataFixtures;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
@@ -82,32 +79,6 @@ public class MetadataRepositoryTest extends WebIntegrationTest {
 
         // THEN:
         assertThat(result.size(), is(equalTo(0)));
-    }
-
-    @Test
-    public void findByLiteralWorks() throws MetadataRepositoryException {
-        // given
-        final Model catalog1 = testMetadataFixtures.catalog1();
-        final Literal title = getTitle(catalog1);
-
-        // when
-        List<SearchResult> result = metadataRepository.findByLiteral(title);
-
-        // then
-        assertThat(result.size(), is(greaterThan(0)));
-    }
-
-    @Test
-    public void findByFilterPredicateWorks() throws MetadataRepositoryException {
-        // given
-        // (value from SettingsFixtures.SEARCH_FILTER_TYPE is private)
-        final String predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-
-        // when
-        final List<SearchFilterValue> result = metadataRepository.findByFilterPredicate(i(predicate));
-
-        // then
-        assertThat(result.size(), is(greaterThan(0)));
     }
 
     @Test

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/search/SearchServiceTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/search/SearchServiceTest.java
@@ -1,0 +1,77 @@
+/**
+ * The MIT License
+ * Copyright © 2017 FAIR Data Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.fairdatateam.fairdatapoint.service.search;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.fairdatateam.fairdatapoint.BaseIntegrationTest;
+import org.fairdatateam.fairdatapoint.database.rdf.repository.MetadataRepositoryException;
+import org.fairdatateam.fairdatapoint.entity.search.SearchFilterValue;
+import org.fairdatateam.fairdatapoint.entity.search.SearchResult;
+import org.fairdatateam.fairdatapoint.utils.TestRdfMetadataFixtures;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.fairdatateam.fairdatapoint.entity.metadata.MetadataGetter.getTitle;
+import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.i;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.core.Is.is;
+
+public class SearchServiceTest extends BaseIntegrationTest {
+
+    @Autowired
+    private SearchService searchService;
+
+    @Autowired
+    private TestRdfMetadataFixtures testMetadataFixtures;
+
+    @Test
+    public void findByLiteralWorks() throws MetadataRepositoryException {
+        // given
+        final Model catalog1 = testMetadataFixtures.catalog1();
+        final Literal title = getTitle(catalog1);
+
+        // when
+        List<SearchResult> result = searchService.findByLiteral(title);
+
+        // then
+        assertThat(result.size(), is(greaterThan(0)));
+    }
+
+    @Test
+    public void findByFilterPredicateWorks() throws MetadataRepositoryException {
+        // given
+        // (value from SettingsFixtures.SEARCH_FILTER_TYPE is private)
+        final String predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+        // when
+        final List<SearchFilterValue> result = searchService.findByFilterPredicate(i(predicate));
+
+        // then
+        assertThat(result.size(), is(greaterThan(0)));
+    }
+
+}


### PR DESCRIPTION
Cleanup for improved cohesion and reuse:

- removed unused methods from `MetadataRepository` and `AbstractMetadataRepository`:
  -  `findResources`
  - `getRepository`
- moved search-related methods from `MetadataRepository` and `AbstractMetadataRepository` into `SearchService` and `SearchMapper` (and adapted tests accordingly):
  - `findByLiteral`
  - `findBySparqlQuery`
  - `findByFilterPredicate`
  - `toSearchResult`
- simplified `runSparqlQuery` method signature and implementation, replacing overloaded method by a new `runSparqlQueryFromFile`
- removed `loadSparqlQuery` in favor of the existing `ResourceReader.loadResource` utility


