### PR TITLE
Configure maven-surefire-plugin to attach mockito agent during tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
         <checkstyle.version>13.3.0</checkstyle.version>
         <spring-javaformat-checkstyle.version>0.0.47</spring-javaformat-checkstyle.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
+
+        <!-- required for mockito to function properly (#890) -->
+        <argLine/>
+
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,19 @@
                 </configuration>
             </plugin>
             <plugin>
+                <!-- required for mockito to function properly (#890) -->
+                <!-- https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#mockito-instrumentation -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -409,6 +422,9 @@
                         <exclude>**/Common.java</exclude>
                         <exclude>**/common/*.java</exclude>
                     </excludes>
+                    <!-- required for mockito to function properly (#890) -->
+                    <!--suppress UnresolvedMavenProperty -->
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Configure maven-surefire-plugin to attach mockito agent during test execution.

Following instructions from [mockito docs].

fixes #890

[mockito docs]: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#mockito-instrumentation

