### PR TITLE
Explicitly shut down SailRepository in ShaclValidator

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/ShaclValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/ShaclValidator.java
@@ -69,6 +69,9 @@ public class ShaclValidator {
             }
             throw new ValidationException("Validation failed (unsupported exception)");
         }
+        finally {
+            sailRepository.shutDown();
+        }
     }
 
 }


### PR DESCRIPTION
This prevents the following error from arising:

>ERROR org.eclipse.rdf4j.sail.shacl.ShaclSail - ShaclSail was garbage collected without shutdown() having been called first.

fixes #891 