### PR TITLE
Remove custom implementation default spring profile

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/Application.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/Application.java
@@ -39,13 +39,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @ConfigurationPropertiesScan("org.fairdatateam.fairdatapoint.config.*")
 public class Application {
 
-    private static final String PROFILES_PROPERTY = "spring.profiles.active";
-
     public static void main(String[] args) {
-        final String property = System.getProperties().getProperty(PROFILES_PROPERTY);
-        if (property == null) {
-            System.setProperty(PROFILES_PROPERTY, Profiles.PRODUCTION);
-        }
         SpringApplication.run(Application.class, args);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ spring:
       pageable:
         default-page-size: 50
         qualifier-delimiter: _
+  profiles:
+    default: production
   task:
     execution:
       pool:


### PR DESCRIPTION
This removes the custom profile stuff from `Application`, so the app now starts to behave as expected.


If we don't specify any active profile, we get the default `default` profile, as expected:

>2026-05-08 18:15:50,958 706  [main] INFO  org.fairdatateam.fairdatapoint.Application - No active profile set, falling back to 1 default profile: "default"

and we override the default in `application.yml` to be the `production` profile (matching the default value from the custom implementation):

>2026-05-08 18:22:26,434 820  [main] INFO  org.fairdatateam.fairdatapoint.Application - No active profile set, falling back to 1 default profile: "production"

During tests we get the expected `testing` profile:

>[INFO ] 18:47:09.430 [main] org.fairdatateam.fairdatapoint.service.metadata.generic.GenericMetadataServiceTest - The following 1 profile is active: "testing"

Now if we specify an active profile explicitly via env variable, it works as expected. For example, with `SPRING_PROFILES_ACTIVE=development`:

>2026-05-08 18:30:26,024 736  [main] INFO  org.fairdatateam.fairdatapoint.Application - The following 1 profile is active: "development"

It also works using command line arguments:

- "program arguments" (after `application.jar`): `--spring.profiles.active=development`
- "JVM" arguments (before `application.jar`): `-Dspring.profiles.active=development`

(in IntelliJ run config these are called "program arguments" and "VM options", respectively)

"Active profiles" in IntelliJ run config also still works, as it did before.

fixes #889
