### PR TITLE
Changelog file deprecation

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,7 +82,7 @@ jobs:
 
     env:
       PUBLIC_IMAGE: fairdata/fairdatapoint
-      TAG_DEVELOP: develop
+      IMAGE_TAG: master
 
     steps:
 
@@ -91,8 +91,8 @@ jobs:
 
       - name: Docker build
         run: |
-          docker pull $PUBLIC_IMAGE:$TAG_DEVELOP
-          docker build --cache-from $PUBLIC_IMAGE:$TAG_DEVELOP -t fdp:snyk-test -f Dockerfile .
+          docker pull $PUBLIC_IMAGE:$IMAGE_TAG
+          docker build --cache-from $PUBLIC_IMAGE:$IMAGE_TAG -t fdp:snyk-test -f Dockerfile .
 
       - name: Perform Snyk Check (Docker)
         uses: snyk/actions/docker@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,12 @@
-# Changelog
+# Changelog (DEPRECATED)
 
-All notable changes to this project will be documented in this file.
+>[!IMPORTANT]
+>From version 1.17.3 onward, all changes are documented on the Github [releases] page, based on pull requests.
+>As a result, this changelog file has been deprecated and is kept only for historical reference.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
-to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 1.17.3 and later
 
-## [Unreleased]
-
-## [1.18.1]
-
-## [1.18.0]
-
-## [1.17.6]
-
-## [1.17.5]
-
-## [1.17.4]
-
-## [1.17.3]
-
-From `1.17.3` upwards, changes are logged using github releases. Click the headers to see changes.
+See [releases] page.
 
 ## [1.17.2]
 
@@ -398,9 +385,5 @@ The first release of reference FAIR Data Point implementation.
 [1.17.0]: /../../tree/v1.17.0
 [1.17.1]: /../../tree/v1.17.1
 [1.17.2]: /../../tree/v1.17.2
-[1.17.3]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/tag/v1.17.3
-[1.17.4]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/tag/v1.17.4
-[1.17.5]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/tag/v1.17.5
-[1.17.6]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/tag/v1.17.6
-[1.18.0]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/tag/v1.18.0
-[1.18.1]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases/tag/v1.18.1
+
+[releases]: https://github.com/FAIRDataTeam/FAIRDataPoint/releases

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/FAIRDataTeam/FAIRDataPoint?sort=semver)](https://github.com/FAIRDataTeam/FAIRDataPoint/releases)
 [![Libraries.io](https://img.shields.io/librariesio/github/FAIRDataTeam/FAIRDataPoint)](https://libraries.io/github/FAIRDataTeam/FAIRDataPoint)
-[![License](https://img.shields.io/github/license/FAIRDataTeam/FAIRDataPoint)](https://github.com/FAIRDataTeam/FAIRDataPoint/blob/develop/LICENSE)
+[![License](https://img.shields.io/github/license/FAIRDataTeam/FAIRDataPoint)](https://github.com/FAIRDataTeam/FAIRDataPoint/blob/master/LICENSE)
 [![Docker Pulls](https://img.shields.io/docker/pulls/fairdata/fairdatapoint)](https://hub.docker.com/r/fairdata/fairdatapoint)
 [![Documentation Status](https://readthedocs.org/projects/fairdatapoint/badge/?version=latest)](https://fairdatapoint.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19236251.svg)](https://doi.org/10.5281/zenodo.19236251)


### PR DESCRIPTION
We use github releases to monitor all changes, so the changelog is redundant.
Moreover, it is a maintenance burden and has been outdated for years.

Also fixed some outdated references to the develop branch.