### PR TITLE
Set spring.profiles.active instead of spring.profiles.default

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
         default-page-size: 50
         qualifier-delimiter: _
   profiles:
-    default: production
+    active: production
   task:
     execution:
       pool:


### PR DESCRIPTION
Even though `spring.profiles.default` *is* used as fallback, and some configuration classes are enabled as a result, apparently it is not picked up everywhere (see issue for details).
On the other hand, `spring.profiles.active` does work properly.

fixes #925