### PR TITLE
Disable actuator metrics by default

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorConfig.java
@@ -42,7 +42,7 @@ public class ActuatorConfig {
      */
     @Bean
     DefaultServerRequestObservationConvention customServerRequestObservationConvention() {
-        log.debug("using custom http.url metric for http.server.requests");
+        log.debug("Using custom http.url metric for http.server.requests.");
         return new DefaultServerRequestObservationConvention() {
             /**
              * Replace the default URI path pattern (e.g. `/catalog/{id}`) with the full URI path (e.g. `/catalog/123`).

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorConfig.java
@@ -23,8 +23,11 @@
 package org.fairdatateam.fairdatapoint.config;
 
 import io.micrometer.common.KeyValue;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
@@ -32,17 +35,31 @@ import org.springframework.http.server.observation.ServerRequestObservationConte
 
 @Slf4j
 @Configuration
-@ConditionalOnProperty(
-        name = "management.metrics.enable.http.server.requests", havingValue = "true", matchIfMissing = false
-)
+@ConditionalOnExpression("'${management.endpoints.web.exposure.include}'.contains('metrics')")
 public class ActuatorConfig {
+
+    /**
+     * Disables all actuator meters except for http.server.requests.
+     * See <a href="https://docs.micrometer.io/micrometer/reference/concepts/meter-filters.html">meter filters</a>.
+     */
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> meterRegistryCustomizer() {
+        final String meterName = "http.server.requests";
+        log.info("Denying all meters except {}", meterName);
+        return registry -> {
+            registry.config().meterFilter(
+                    MeterFilter.denyUnless(id -> {
+                        return id.getName().equals(meterName);
+                    }));
+        };
+    }
 
     /**
      * Replaces the default `uri` path-pattern values with full paths in actuator metrics http.server.requests
      */
     @Bean
     DefaultServerRequestObservationConvention customServerRequestObservationConvention() {
-        log.debug("Using custom http.url metric for http.server.requests.");
+        log.info("Using custom http.url metric for http.server.requests.");
         return new DefaultServerRequestObservationConvention() {
             /**
              * Replace the default URI path pattern (e.g. `/catalog/{id}`) with the full URI path (e.g. `/catalog/123`).

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorConfig.java
@@ -23,12 +23,18 @@
 package org.fairdatateam.fairdatapoint.config;
 
 import io.micrometer.common.KeyValue;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 
+@Slf4j
 @Configuration
+@ConditionalOnProperty(
+        name = "management.metrics.enable.http.server.requests", havingValue = "true", matchIfMissing = false
+)
 public class ActuatorConfig {
 
     /**
@@ -36,6 +42,7 @@ public class ActuatorConfig {
      */
     @Bean
     DefaultServerRequestObservationConvention customServerRequestObservationConvention() {
+        log.debug("using custom http.url metric for http.server.requests");
         return new DefaultServerRequestObservationConvention() {
             /**
              * Replace the default URI path pattern (e.g. `/catalog/{id}`) with the full URI path (e.g. `/catalog/123`).

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
@@ -56,10 +56,7 @@ public class ActuatorMetricsConfig {
         final String meterName = "http.server.requests";
         log.info("Denying all meters except {}", meterName);
         return registry -> {
-            registry.config().meterFilter(
-                    MeterFilter.denyUnless(id -> {
-                        return id.getName().equals(meterName);
-                    }));
+            registry.config().meterFilter(MeterFilter.denyUnless(id -> id.getName().equals(meterName)));
         };
     }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
@@ -41,6 +41,15 @@ public class ActuatorMetricsConfig {
     /**
      * Disables all actuator meters except for http.server.requests.
      * See <a href="https://docs.micrometer.io/micrometer/reference/concepts/meter-filters.html">meter filters</a>.
+     * This is the equivalent of the following <code>application.yml</code> settings:
+     * <pre>
+     *     management:
+     *       metrics:
+     *         enable:
+     *           all: false
+     *           http.server.requests: true
+     *           http.server.requests.active: false
+     * </pre>
      */
     @Bean
     public MeterRegistryCustomizer<MeterRegistry> meterRegistryCustomizer() {

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
@@ -36,7 +36,7 @@ import org.springframework.http.server.observation.ServerRequestObservationConte
 @Slf4j
 @Configuration
 @ConditionalOnExpression("'${management.endpoints.web.exposure.include}'.contains('metrics')")
-public class ActuatorConfig {
+public class ActuatorMetricsConfig {
 
     /**
      * Disables all actuator meters except for http.server.requests.

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/ActuatorMetricsConfig.java
@@ -38,6 +38,8 @@ import org.springframework.http.server.observation.ServerRequestObservationConte
 @ConditionalOnExpression("'${management.endpoints.web.exposure.include}'.contains('metrics')")
 public class ActuatorMetricsConfig {
 
+    private final String meterName = "http.server.requests";
+
     /**
      * Disables all actuator meters except for http.server.requests.
      * See <a href="https://docs.micrometer.io/micrometer/reference/concepts/meter-filters.html">meter filters</a>.
@@ -53,7 +55,6 @@ public class ActuatorMetricsConfig {
      */
     @Bean
     public MeterRegistryCustomizer<MeterRegistry> meterRegistryCustomizer() {
-        final String meterName = "http.server.requests";
         log.info("Denying all meters except {}", meterName);
         return registry -> {
             registry.config().meterFilter(MeterFilter.denyUnless(id -> id.getName().equals(meterName)));
@@ -61,11 +62,11 @@ public class ActuatorMetricsConfig {
     }
 
     /**
-     * Replaces the default `uri` path-pattern values with full paths in actuator metrics http.server.requests
+     * Replaces the default uri path-pattern values with full paths in actuator metrics http.server.requests
      */
     @Bean
     DefaultServerRequestObservationConvention customServerRequestObservationConvention() {
-        log.info("Using custom http.url metric for http.server.requests.");
+        log.info("Using custom http.url metric for {}.", meterName);
         return new DefaultServerRequestObservationConvention() {
             /**
              * Replace the default URI path pattern (e.g. `/catalog/{id}`) with the full URI path (e.g. `/catalog/123`).

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,11 +32,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics
+        # to expose custom http.server.requests http.url metric, include "metrics", and enable http.server.requests
+        include: health, info
   metrics:
+    # enables internal collection of metrics, regardless of exposure
     enable:
       all: false
-      http.server.requests: true
+      # set http.server.requests true to enable custom http.url metric
+      http.server.requests: false
       http.server.requests.active: false
 
 security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,15 +32,9 @@ management:
   endpoints:
     web:
       exposure:
-        # to expose custom http.server.requests http.url metric, include "metrics", and enable http.server.requests
+        # To expose custom http.server.requests http.url metric, include "metrics".
+        # Note the ActuatorConfig ensures that only the http.server.requests meter is enabled.
         include: health, info
-  metrics:
-    # enables internal collection of metrics, regardless of exposure
-    enable:
-      all: false
-      # set http.server.requests true to enable custom http.url metric
-      http.server.requests: false
-      http.server.requests.active: false
 
 security:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ management:
       exposure:
         # To expose custom http.server.requests http.url metric, include "metrics".
         # This can also be done using env variable MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE.
-        # Note the ActuatorConfig ensures that only the http.server.requests meter is enabled.
+        # Note the ActuatorMetricsConfig ensures that only the http.server.requests meter is enabled.
         include: health, info
 
 security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ management:
     web:
       exposure:
         # To expose custom http.server.requests http.url metric, include "metrics".
+        # This can also be done using env variable MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE.
         # Note the ActuatorConfig ensures that only the http.server.requests meter is enabled.
         include: health, info
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/MetricsTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/MetricsTest.java
@@ -45,10 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles(Profiles.TESTING)
 @AutoConfigureMockMvc
-@SpringBootTest(properties = {
-        "management.endpoints.web.exposure.include=health,info,metrics",
-        "management.metrics.enable.http.server.requests=true"
-})
+@SpringBootTest(properties = {"management.endpoints.web.exposure.include=health,info,metrics"})
 @WithMockUser
 class MetricsTest {
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/MetricsTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/actuator/MetricsTest.java
@@ -45,7 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles(Profiles.TESTING)
 @AutoConfigureMockMvc
-@SpringBootTest
+@SpringBootTest(properties = {
+        "management.endpoints.web.exposure.include=health,info,metrics",
+        "management.metrics.enable.http.server.requests=true"
+})
 @WithMockUser
 class MetricsTest {
 


### PR DESCRIPTION
Refactored configuration of the actuator `http.server.requests` metrics in order to make it opt-in instead of opt-out.

The (experimental) metrics are now disabled by default and can be enabled by exposing the `metrics` endpoint, as in `management.endpoints.web.exposure.include=health,info,metrics` (default is `health,info`).

This can also be done using an environment variable:

`MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,metrics`

The `application.yml` based metrics filtering has been replaced by a new `MeterRegistryCustomizer` bean, which denies all meters except `http.server.requests`.
This simplifies configuration for users, because they only need to worry about exposing the metrics endpoint as described above.

In addition, `ActuatorConfig` was renamed to `ActuatorMetricsConfig` for clarity.

related to #836