### PR TITLE
Checkstyle allow long URLs in inline comments

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -190,7 +190,8 @@
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
         <property name="max" value="120"/>
-        <property name="ignorePattern" value="^ *\* *([^ ]+|\{@code .*|&lt;a href=&quot;[^&quot;]+&quot;&gt;)$"/>
+        <!-- allow long single words (e.g. urls) in javadoc and inline comments -->
+        <property name="ignorePattern" value="^ *(\*|\/{2}) *([^ ]+|\{@code .*|&lt;a href=&quot;[^&quot;]+&quot;&gt;)$"/>
     </module>
 
     <!-- Whitespace -->


### PR DESCRIPTION
Checkstyle was already configured to ignore lines with long single words, such as long URLs, in javadoc comments, i.e. lines starting with `*`.

Now we apply the same ignore rule also to inline comments, i.e. lines starting with `//`.

