### PR TITLE
Upgrade to Jackson 3

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaDraftDTO.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/dto/schema/MetadataSchemaDraftDTO.java
@@ -47,7 +47,7 @@ public class MetadataSchemaDraftDTO {
     @NotNull
     private String description;
 
-    private boolean abstractSchema;
+    private Boolean abstractSchema;
 
     @NotNull
     private String definition;

--- a/src/main/java/org/fairdatateam/fairdatapoint/api/filter/JwtTokenFilter.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/api/filter/JwtTokenFilter.java
@@ -22,7 +22,6 @@
  */
 package org.fairdatateam.fairdatapoint.api.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +37,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 
@@ -53,7 +53,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     private ApiKeyService apiKeyService;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     @Override
     public void doFilterInternal(
@@ -69,7 +69,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType(MediaType.APPLICATION_JSON.toString());
             final ErrorDTO error = new ErrorDTO(HttpStatus.UNAUTHORIZED, "You have to be log in");
-            objectMapper.writeValue(response.getWriter(), error);
+            jsonMapper.writeValue(response.getWriter(), error);
         }
     }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/config/WebMvcConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/config/WebMvcConfig.java
@@ -22,8 +22,7 @@
  */
 package org.fairdatateam.fairdatapoint.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.fairdatateam.fairdatapoint.api.converter.ErrorConverter;
 import org.fairdatateam.fairdatapoint.api.converter.RdfConverter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,15 +33,15 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -59,7 +58,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         converters.addAll(errorConverters);
         converters.addAll(rdfConverters);
         converters.add(new ByteArrayHttpMessageConverter());
-        converters.add(new MappingJackson2HttpMessageConverter(objectMapper()));
+        converters.add(new JacksonJsonHttpMessageConverter(jsonMapper()));
     }
 
     @Override
@@ -75,12 +74,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Bean
     @Primary
-    public ObjectMapper objectMapper() {
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.findAndRegisterModules();
-        mapper.setSerializationInclusion(NON_NULL);
-        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        return mapper;
+    public JsonMapper jsonMapper() {
+        return JsonMapper.builder()
+                // https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.9.8/com/fasterxml/jackson/databind/ObjectMapper.html#findAndRegisterModules--
+                // https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md#objectmapper-serialization-inclusion-configuration
+                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+                .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL))
+                // https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md#objectmapper-visibility-configuration
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
     }
 
     @Bean

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/EventService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/EventService.java
@@ -22,7 +22,6 @@
  */
 package org.fairdatateam.fairdatapoint.service.index.event;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
@@ -57,6 +56,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -70,7 +70,7 @@ public class EventService {
     private static final int PAGE_SIZE = 10;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     @Autowired
     private ThreadPoolTaskExecutor executor;
@@ -155,7 +155,7 @@ public class EventService {
             event.getIncomingPing().getExchange().getResponse()
                     .setCode(HttpStatus.BAD_REQUEST.value());
             event.getIncomingPing().getExchange().getResponse()
-                    .setBody(objectMapper.writeValueAsString(nextException.getErrorDTO()));
+                    .setBody(jsonMapper.writeValueAsString(nextException.getErrorDTO()));
             event.setFinished(Instant.now());
             eventRepository.save(event);
             log.info("Incoming ping has incorrect format: {}", exception.getMessage());

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/IncomingPingUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/event/IncomingPingUtils.java
@@ -22,8 +22,6 @@
  */
 package org.fairdatateam.fairdatapoint.service.index.event;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.fairdatateam.fairdatapoint.api.dto.index.ping.PingDTO;
 import org.fairdatateam.fairdatapoint.entity.index.event.Event;
@@ -32,6 +30,8 @@ import org.fairdatateam.fairdatapoint.entity.index.http.Exchange;
 import org.fairdatateam.fairdatapoint.entity.index.http.ExchangeDirection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.*;
 
@@ -41,7 +41,7 @@ public class IncomingPingUtils {
     private static final Integer VERSION = 1;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     public Event prepareEvent(PingDTO reqDto, HttpServletRequest request, String remoteAddr) {
         final IncomingPing incomingPing = new IncomingPing();
@@ -51,9 +51,9 @@ public class IncomingPingUtils {
         ex.getRequest().setHeaders(getHeaders(request));
         ex.getRequest().setFromHttpServletRequest(request);
         try {
-            ex.getRequest().setBody(objectMapper.writeValueAsString(reqDto));
+            ex.getRequest().setBody(jsonMapper.writeValueAsString(reqDto));
         }
-        catch (JsonProcessingException exception) {
+        catch (JacksonException exception) {
             ex.getRequest().setBody(null);
         }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/index/webhook/WebhookService.java
@@ -22,8 +22,6 @@
  */
 package org.fairdatateam.fairdatapoint.service.index.webhook;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.fairdatateam.fairdatapoint.api.dto.index.webhook.WebhookPayloadDTO;
@@ -42,6 +40,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
@@ -57,7 +57,7 @@ public class WebhookService {
     private WebhookMapper webhookMapper;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     @Autowired
     private WebhookRepository webhookRepository;
@@ -79,10 +79,10 @@ public class WebhookService {
         eventRepository.save(event);
         final WebhookPayloadDTO webhookPayload = webhookMapper.toWebhookPayloadDTO(event);
         try {
-            final String payloadWithSecret = objectMapper.writeValueAsString(webhookPayload);
+            final String payloadWithSecret = jsonMapper.writeValueAsString(webhookPayload);
             final String signature = WebhookUtils.computeHashSignature(payloadWithSecret);
             webhookPayload.setSecret(SECRET_PLACEHOLDER);
-            final String payloadWithoutSecret = objectMapper.writeValueAsString(webhookPayload);
+            final String payloadWithoutSecret = jsonMapper.writeValueAsString(webhookPayload);
             WebhookUtils.postWebhook(
                     event,
                     retrievalSettings.getTimeout(),
@@ -90,7 +90,7 @@ public class WebhookService {
                     signature
             );
         }
-        catch (JsonProcessingException exception) {
+        catch (JacksonException exception) {
             log.error("Failed to convert webhook payload to string");
         }
         catch (NoSuchAlgorithmException exception) {

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaRetrievalUtils.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/schema/MetadataSchemaRetrievalUtils.java
@@ -22,13 +22,13 @@
  */
 package org.fairdatateam.fairdatapoint.service.schema;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.fairdatateam.fairdatapoint.api.dto.schema.MetadataSchemaVersionDTO;
 import org.fairdatateam.fairdatapoint.entity.exception.MetadataSchemaImportException;
 import org.springframework.http.HttpHeaders;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -49,7 +49,7 @@ public class MetadataSchemaRetrievalUtils {
             .connectTimeout(Duration.ofMinutes(1))
             .build();
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = new JsonMapper();
 
     private static final TypeReference<List<MetadataSchemaVersionDTO>> RESPONSE_TYPE =
             new TypeReference<>() {
@@ -64,9 +64,9 @@ public class MetadataSchemaRetrievalUtils {
                     .GET().build();
             final HttpResponse<String> response =
                     HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-            return OBJECT_MAPPER.readValue(response.body(), RESPONSE_TYPE);
+            return JSON_MAPPER.readValue(response.body(), RESPONSE_TYPE);
         }
-        catch (JsonProcessingException exception) {
+        catch (JacksonException exception) {
             log.warn(
                     format("Could not parse published metadata schemas from %s: %s",
                             fdpUrl, exception.getMessage())

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_PUT.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/schema/Draft_PUT.java
@@ -103,7 +103,7 @@ public class Draft_PUT extends WebIntegrationTest {
         assertThat(result.getBody().getName(), is(equalTo(reqDto.getName())));
         assertThat(result.getBody().getDescription(), is(equalTo(reqDto.getDescription())));
         assertThat(result.getBody().getDefinition(), is(equalTo(reqDto.getDefinition())));
-        assertThat(result.getBody().isAbstractSchema(), is(equalTo(reqDto.isAbstractSchema())));
+        assertThat(result.getBody().getAbstractSchema(), is(equalTo(reqDto.isAbstractSchema())));
         assertThat(result.getBody().getExtendsSchemaUuids(), is(equalTo(reqDto.getExtendsSchemaUuids())));
     }
 


### PR DESCRIPTION
- replaced `ObjectMapper` by `JsonMapper` with new builder api
- fixed corresponding imports:
  `com.fasterxml.jackson` moved to `tools.jackson` except for `com.fasterxml.jackson.annotation`
- replaced `JsonProcessingException` by `JacksonException`
- replaced `MappingJackson2HttpMessageConverter` by `JacksonJsonHttpMessageConverter` (actually a spring thing but the former is deprecated and does not accept `JsonMapper`)



fixes #933 