### PR TITLE
Trigger end-to-end tests in docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,3 +34,20 @@ jobs:
       push: ${{ github.event_name == 'push' || github.event_name == 'release' }}
       build-args: |
         "PROJECT_VERSION=${{ github.ref_name }}"
+  e2e:
+    # The end-to-end tests get the docker image from docker hub, so the image needs to be published first.
+    # This makes most sense for pushes to the master branch, before the actual release takes place.
+    # Nevertheless, it does provide extra verification for the release case as well.
+    needs: publish
+    uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch@issue14-repo-dispatch
+    secrets: inherit
+    with:
+      secret-token: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
+      target-repo-name: FAIRDataPoint-E2E-Tests
+      target-repo-owner: FAIRDataTeam
+      event-type: trigger-tests
+      client-payload: |
+        {
+            "fdp_version": "${{ github.ref_name }}",
+            "fdp_client_version": "latest"
+        }

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
     # This makes most sense for pushes to the master branch, before the actual release takes place.
     # Nevertheless, it does provide extra verification for the release case as well.
     needs: publish
-    uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch@issue14-repo-dispatch
+    uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch@v3
     secrets: inherit
     with:
       secret-token: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}


### PR DESCRIPTION
Added an end-to-end (e2e) testing step to the docker-publish github workflow.

This workflow step triggers a repository_dispatch event in the [FAIRDataTeam/FAIRDataPoint-E2E-Tests] repo.

todo:

- [x] update tag for `repo-dispatch` action

also see fix in #939 

[FAIRDataTeam/FAIRDataPoint-E2E-Tests]: https://github.com/FAIRDataTeam/FAIRDataPoint-E2E-Tests