### PR TITLE
Fix docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,16 +39,17 @@ jobs:
     # This makes most sense for pushes to the master branch, before the actual release takes place.
     # Nevertheless, it does provide extra verification for the release case as well.
     needs: publish
-    uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch/action.yml@v3
-    env:
-      SECRET_TOKEN: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
-    with:
-      secret-token: ${{ env.SECRET_TOKEN }}
-      target-repo-name: FAIRDataPoint-E2E-Tests
-      target-repo-owner: FAIRDataTeam
-      event-type: trigger-tests
-      client-payload: |
-        {
-            "fdp_version": "${{ github.ref_name }}",
-            "fdp_client_version": "latest"
-        }
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger e2e tests
+        uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch/action.yml@v3
+        with:
+          secret-token: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
+          target-repo-name: FAIRDataPoint-E2E-Tests
+          target-repo-owner: FAIRDataTeam
+          event-type: trigger-tests
+          client-payload: |
+            {
+                "fdp_version": "${{ github.ref_name }}",
+                "fdp_client_version": "latest"
+            }

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,8 +41,10 @@ jobs:
     needs: publish
     uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch/action.yml@v3
     secrets: inherit
+    env:
+      SECRET_TOKEN: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
     with:
-      secret-token: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
+      secret-token: ${{ env.SECRET_TOKEN }}
       target-repo-name: FAIRDataPoint-E2E-Tests
       target-repo-owner: FAIRDataTeam
       event-type: trigger-tests

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: trigger e2e tests
-        uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch/action.yml@v3
+        uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch@v3
         with:
           secret-token: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
           target-repo-name: FAIRDataPoint-E2E-Tests

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,6 @@ jobs:
     # Nevertheless, it does provide extra verification for the release case as well.
     needs: publish
     uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch/action.yml@v3
-    secrets: inherit
     env:
       SECRET_TOKEN: ${{ secrets.FDP_E2E_REPO_DISPATCH_TOKEN }}
     with:


### PR DESCRIPTION
In #938 we accidentally forgot to call the action from a workflow step, effectively treating the action as a reusable workflow. This caused confusing errors like:

>Invalid workflow file: .github/workflows/docker-publish.yml#L1
>(Line: 45, Col: 21): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.FDP_E2E_REPO_DISPATCH_TOKEN

This is fixed now.