### PR TITLE
Strip whitespace and improved logging for getClientIpAddress

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
@@ -75,13 +75,13 @@ public class HttpUtil {
             for (String header : IP_HEADER_CANDIDATES) {
                 final String ipList = request.getHeader(header);
                 if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
-                    log.debug("IP list: {}", ipList);
+                    log.debug("Using first IP from {} header: {}", header, ipList);
                     clientIp = ipList.split(",")[0];
                     break;
                 }
             }
         }
-        log.info("Remote client IP: {}", clientIp);
+        log.debug("Remote client IP: {}", clientIp);
         return clientIp.strip();
     }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
@@ -82,7 +82,7 @@ public class HttpUtil {
             }
         }
         log.info("Remote client IP: {}", clientIp);
-        return clientIp;
+        return clientIp.strip();
     }
 
     public static String getRequestURL(HttpServletRequest request, String persistentUrl) {

--- a/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/util/HttpUtil.java
@@ -69,15 +69,20 @@ public class HttpUtil {
     };
 
     public static String getClientIpAddress(HttpServletRequest request, Boolean behindProxy) {
+        String clientIp = request.getRemoteAddr();
+        log.debug("Remote address: {}", clientIp);
         if (behindProxy) {
             for (String header : IP_HEADER_CANDIDATES) {
                 final String ipList = request.getHeader(header);
                 if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
-                    return ipList.split(",")[0];
+                    log.debug("IP list: {}", ipList);
+                    clientIp = ipList.split(",")[0];
+                    break;
                 }
             }
         }
-        return request.getRemoteAddr();
+        log.info("Remote client IP: {}", clientIp);
+        return clientIp;
     }
 
     public static String getRequestURL(HttpServletRequest request, String persistentUrl) {


### PR DESCRIPTION
- Strip possible whitespace from the IP address string returned by `getClientIpAddress`
- Refactored to single return statement (to facilitate strip and logging)
- Added debug logging
