### PR TITLE
Add dcat:endpointDescription statement to fdp rdf representation

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
@@ -36,6 +36,7 @@ import org.fairdatateam.fairdatapoint.vocabulary.FDP;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.vocabulary.*;
+import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -55,6 +56,10 @@ import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.l;
 
 @Service
 public class MetadataEnhancer {
+
+    // https://springdoc.org/#springdoc-openapi-core-properties
+    @Autowired
+    private SpringDocConfigProperties springDocConfig;
 
     @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
@@ -165,6 +170,8 @@ public class MetadataEnhancer {
         if (definition.isRoot()) {
             resultRdf.add(entityUri, FDP.FDPSOFTWAREVERSION, l(format("FDP:%s", appInfoContributor.getFdpVersion())));
             resultRdf.add(entityUri, DCAT.ENDPOINT_URL, i(persistentUrl));
+            final String apiDocsPath = springDocConfig.getApiDocs().getPath();
+            resultRdf.add(entityUri, DCAT.ENDPOINT_DESCRIPTION, i(persistentUrl + apiDocsPath));
         }
     }
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
@@ -25,6 +25,7 @@ package org.fairdatateam.fairdatapoint.acceptance.metadata.repository;
 import org.fairdatateam.fairdatapoint.WebIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -34,11 +35,15 @@ import org.springframework.http.ResponseEntity;
 import java.net.URI;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @DisplayName("GET /")
 public class Detail_GET extends WebIntegrationTest {
+
+    @Autowired
+    private String persistentUrl;
 
     private URI url() {
         return URI.create("/");
@@ -60,6 +65,12 @@ public class Detail_GET extends WebIntegrationTest {
 
         // THEN:
         assertThat(result.getStatusCode(), is(equalTo(HttpStatus.OK)));
+        final String body = result.getBody();
+        assert body != null;
+        // check dcat:endpoint* statements
+        assertThat(body, containsString("dcat:endpointURL <%s>".formatted(persistentUrl)));
+        final String apiDocsPath = "/v3/api-docs";
+        assertThat(body, containsString("dcat:endpointDescription <%s%s>".formatted(persistentUrl, apiDocsPath)));
     }
 
 }

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
@@ -67,10 +67,10 @@ public class Detail_GET extends WebIntegrationTest {
         assertThat(result.getStatusCode(), is(equalTo(HttpStatus.OK)));
         final String body = result.getBody();
         assert body != null;
-        // check dcat:endpoint* statements
-        assertThat(body, containsString("dcat:endpointURL <%s>".formatted(persistentUrl)));
+        // https://springdoc.org/#springdoc-openapi-core-properties (but we write the expected value explicitly here)
         final String apiDocsPath = "/v3/api-docs";
         assertThat(body, containsString("dcat:endpointDescription <%s%s>".formatted(persistentUrl, apiDocsPath)));
+        assertThat(body, containsString("dcat:endpointURL <%s>".formatted(persistentUrl)));
     }
 
 }


### PR DESCRIPTION
Gets the api docs path (`/v3/api-docs` by default) from the [springdoc-openapi config] and adds a `dcat:endpointDescription` statement to the FDP's RDF representation, via the `MetadataEnhancer` (which also adds the `dcat:endpointURL` statement).

Amended test to check for these statements.

fixes #950 

[springdoc-openapi config]: https://springdoc.org/#springdoc-openapi-core-properties