### PR TITLE
Add dcat:endpointDescription statement for swagger-ui 

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
@@ -175,8 +175,8 @@ public class MetadataEnhancer {
             resultRdf.add(entityUri, FDP.FDPSOFTWAREVERSION, l(format("FDP:%s", appInfoContributor.getFdpVersion())));
             resultRdf.add(entityUri, DCAT.ENDPOINT_URL, i(persistentUrl));
             // add dcat:endpointDescription statements for api-docs path and swagger-ui path from config
-            List.of(springDocConfig.getApiDocs().getPath(), swaggerUiConfig.getPath()).forEach(path ->
-                    resultRdf.add(entityUri, DCAT.ENDPOINT_DESCRIPTION, i(persistentUrl + path)));
+            List.of(springDocConfig.getApiDocs().getPath(), swaggerUiConfig.getPath()).forEach(
+                    path -> resultRdf.add(entityUri, DCAT.ENDPOINT_DESCRIPTION, i(persistentUrl + path)));
         }
     }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/enhance/MetadataEnhancer.java
@@ -37,6 +37,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.vocabulary.*;
 import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,6 +61,9 @@ public class MetadataEnhancer {
     // https://springdoc.org/#springdoc-openapi-core-properties
     @Autowired
     private SpringDocConfigProperties springDocConfig;
+
+    @Autowired
+    private SwaggerUiConfigProperties swaggerUiConfig;
 
     @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
@@ -170,8 +174,9 @@ public class MetadataEnhancer {
         if (definition.isRoot()) {
             resultRdf.add(entityUri, FDP.FDPSOFTWAREVERSION, l(format("FDP:%s", appInfoContributor.getFdpVersion())));
             resultRdf.add(entityUri, DCAT.ENDPOINT_URL, i(persistentUrl));
-            final String apiDocsPath = springDocConfig.getApiDocs().getPath();
-            resultRdf.add(entityUri, DCAT.ENDPOINT_DESCRIPTION, i(persistentUrl + apiDocsPath));
+            // add dcat:endpointDescription statements for api-docs path and swagger-ui path from config
+            List.of(springDocConfig.getApiDocs().getPath(), swaggerUiConfig.getPath()).forEach(path ->
+                    resultRdf.add(entityUri, DCAT.ENDPOINT_DESCRIPTION, i(persistentUrl + path)));
         }
     }
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
@@ -76,8 +76,8 @@ public class Detail_GET extends WebIntegrationTest {
         lines.forEach(line -> {
             if (line.contains(endpointDescription)) {
                 // https://springdoc.org/#springdoc-openapi-core-properties (expected values intentionally hard-coded)
-                List.of("/v3/api-docs", "/swagger-ui.html").forEach(expectedPath ->
-                        assertThat(line, containsString(persistentUrl + expectedPath)));
+                List.of("/v3/api-docs", "/swagger-ui.html").forEach(
+                        expectedPath -> assertThat(line, containsString(persistentUrl + expectedPath)));
             }
         });
     }

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
@@ -68,11 +68,18 @@ public class Detail_GET extends WebIntegrationTest {
         assertThat(result.getStatusCode(), is(equalTo(HttpStatus.OK)));
         final String body = result.getBody();
         assert body != null;
-        // https://springdoc.org/#springdoc-openapi-core-properties (but we write the expected value explicitly here)
-        final String pattern = "dcat:endpointDescription <%s%s>";
-        List.of("/v3/api-docs", "/swagger-ui.html").forEach(expectedPath ->
-                assertThat(body, containsString(pattern.formatted(persistentUrl, expectedPath))));
         assertThat(body, containsString("dcat:endpointURL <%s>".formatted(persistentUrl)));
+        // check that a line exists with endpoint descriptions for api-docs and swagger-ui (handles turtle syntax)
+        final String endpointDescription = "dcat:endpointDescription";
+        assertThat(body, containsString(endpointDescription));
+        final List<String> lines = List.of(body.split("\n"));
+        lines.forEach(line -> {
+            if (line.contains(endpointDescription)) {
+                // https://springdoc.org/#springdoc-openapi-core-properties (expected values intentionally hard-coded)
+                List.of("/v3/api-docs", "/swagger-ui.html").forEach(expectedPath ->
+                        assertThat(line, containsString(persistentUrl + expectedPath)));
+            }
+        });
     }
 
 }

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/repository/Detail_GET.java
@@ -33,6 +33,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -68,8 +69,9 @@ public class Detail_GET extends WebIntegrationTest {
         final String body = result.getBody();
         assert body != null;
         // https://springdoc.org/#springdoc-openapi-core-properties (but we write the expected value explicitly here)
-        final String apiDocsPath = "/v3/api-docs";
-        assertThat(body, containsString("dcat:endpointDescription <%s%s>".formatted(persistentUrl, apiDocsPath)));
+        final String pattern = "dcat:endpointDescription <%s%s>";
+        List.of("/v3/api-docs", "/swagger-ui.html").forEach(expectedPath ->
+                assertThat(body, containsString(pattern.formatted(persistentUrl, expectedPath))));
         assertThat(body, containsString("dcat:endpointURL <%s>".formatted(persistentUrl)));
     }
 


### PR DESCRIPTION
Added a second `dcat:endpointDescription` statement, now for the *human-readable* `/swagger-ui.html` docs.

The swagger-ui is not machine readable, but that is not strictly required according to the fdp-spec. Also [DCAT3] says 

>An endpoint description [may] be expressed in a machine-readable form [...]

This indirectly fixes the following issues, because the endpoint descriptions are displayed in the client as clickable links:
- FAIRDataTeam/FAIRDataPoint-client#174
- FAIRDataTeam/FAIRDataPoint-client-redux#42

[allow multiple]: https://github.com/fdp-specs/fdp-specs.github.io/blob/ae9abd71be749bb6825f76a389fcae52fe2a45d5/src/tables/table-fdp-metadata.html#L111-L113
[DCAT3]: https://www.w3.org/TR/vocab-dcat-3/#Property:data_service_endpoint_description
[may]: https://www.rfc-editor.org/info/rfc2119/#section-5

follow up for #952