### PR TITLE
Upgrade to RDF4J 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,22 +237,23 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-runtime</artifactId>
-            <type>pom</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>rdf4j-repository-http</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-rio-api</artifactId>
+            <artifactId>rdf4j-repository-manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-sail-memory</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-sail-nativerdf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-shacl</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <!-- Core -->
         <springdoc-openapi-starter-webmvc-ui.version>3.0.3</springdoc-openapi-starter-webmvc-ui.version>
         <mongock-bom.version>5.5.1</mongock-bom.version>
-        <rdf4j-runtime.version>5.3.1</rdf4j-runtime.version>
+        <rdf4j-runtime.version>6.0.0</rdf4j-runtime.version>
         <jjwt-api.version>0.13.0</jjwt-api.version>
 
         <!-- Plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <!-- Core -->
         <springdoc-openapi-starter-webmvc-ui.version>3.0.3</springdoc-openapi-starter-webmvc-ui.version>
         <mongock-bom.version>5.5.1</mongock-bom.version>
-        <rdf4j-runtime.version>6.0.0</rdf4j-runtime.version>
+        <rdf4j-bom.version>6.0.0</rdf4j-bom.version>
         <jjwt-api.version>0.13.0</jjwt-api.version>
 
         <!-- Plugins -->
@@ -85,6 +85,14 @@
                 <groupId>io.mongock</groupId>
                 <artifactId>mongock-bom</artifactId>
                 <version>${mongock-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <!-- https://rdf4j.org/documentation/tutorials/maven-eclipse-project/ -->
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-bom</artifactId>
+                <version>${rdf4j-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -230,7 +238,6 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-runtime</artifactId>
-            <version>${rdf4j-runtime.version}</version>
             <type>pom</type>
             <exclusions>
                 <exclusion>
@@ -242,12 +249,10 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-rio-api</artifactId>
-            <version>${rdf4j-runtime.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-sail-nativerdf</artifactId>
-            <version>${rdf4j-runtime.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,9 +244,20 @@
             <artifactId>rdf4j-repository-manager</artifactId>
         </dependency>
         <dependency>
-            <!-- already a transitive dependency, but we make it explicit because of org.eclipse.rdf4j.rio imports -->
             <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-rio-api</artifactId>
+            <artifactId>rdf4j-rio-jsonld</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-n3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfxml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-turtle</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,11 @@
             <artifactId>rdf4j-repository-manager</artifactId>
         </dependency>
         <dependency>
+            <!-- already a transitive dependency, but we make it explicit because of org.eclipse.rdf4j.rio imports -->
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-sail-memory</artifactId>
         </dependency>

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/catalog/CatalogMetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/catalog/CatalogMetadataService.java
@@ -33,7 +33,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 
 import static org.fairdatateam.fairdatapoint.entity.metadata.MetadataSetter.setThemeTaxonomies;

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/metric/MetricsMetadataService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/metric/MetricsMetadataService.java
@@ -36,7 +36,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 
 import static java.lang.String.format;

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/search/SearchService.java
@@ -34,7 +34,7 @@ import org.fairdatateam.fairdatapoint.entity.search.SearchResult;
 import org.fairdatateam.fairdatapoint.entity.settings.SettingsSearchFilter;
 import org.fairdatateam.fairdatapoint.service.metadata.state.MetadataStateService;
 import org.fairdatateam.fairdatapoint.service.settings.SettingsService;
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.text.StrSubstitutor;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/ContentNegotiationTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/ContentNegotiationTest.java
@@ -23,9 +23,9 @@
 package org.fairdatateam.fairdatapoint.acceptance.general;
 
 import org.fairdatateam.fairdatapoint.WebIntegrationTest;
-import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/ContentNegotiationTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/ContentNegotiationTest.java
@@ -24,6 +24,8 @@ package org.fairdatateam.fairdatapoint.acceptance.general;
 
 import org.fairdatateam.fairdatapoint.WebIntegrationTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -56,11 +58,21 @@ public class ContentNegotiationTest extends WebIntegrationTest {
         assertThat(result.getHeaders().getContentType().toString(), is(equalTo("text/turtle")));
     }
 
-    @Test
-    public void getContentAccordingToFormatQueryString() {
+    @ParameterizedTest
+    @CsvSource({
+            "'', text/turtle",
+            "jsonld, application/ld+json",
+            "n3, text/n3",
+            "rdf, application/rdf+xml",
+            "ttl, text/turtle",
+            "xml, application/xml"
+    })
+    public void getContentAccordingToFormatQueryString(String format, String expectedContentType) {
         // GIVEN:
         RequestEntity<Void> request = RequestEntity
-                .get(URI.create("/?format=rdf"))
+                .get(URI.create("/?format=" + format))
+                // explicitly override the accept header to make sure empty format work as expected
+                .header(HttpHeaders.ACCEPT, "*/*")
                 .build();
         ParameterizedTypeReference<String> responseType = new ParameterizedTypeReference<>() {
         };
@@ -70,7 +82,7 @@ public class ContentNegotiationTest extends WebIntegrationTest {
 
         // THEN:
         assertThat(result.getStatusCode(), is(equalTo(HttpStatus.OK)));
-        assertThat(result.getHeaders().getContentType().toString(), is(equalTo("application/rdf+xml")));
+        assertThat(result.getHeaders().getContentType().toString(), is(equalTo(expectedContentType)));
     }
 
     @Test

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/CorsTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/general/CorsTest.java
@@ -22,7 +22,6 @@
  */
 package org.fairdatateam.fairdatapoint.acceptance.general;
 
-import org.eclipse.jetty.http.HttpHeader;
 import org.fairdatateam.fairdatapoint.Profiles;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
- upgraded RDF4J from 5.x to 6.0.0 (see [release-notes])
- switched to `rdf4j-bom` for dependency version management
- replaced full `rdf4j-runtime` dependency (which contains all modules) by only the individual rdf4j modules that are actually needed (this means more lines in the pom.xml, but a cleaner dependency tree)
- cleaned up some related imports
- improved the content negotiation test so it actually tests all the supported RDF formats

fixes #959

[release-notes]: https://rdf4j.org/release-notes/6.0.0/