### PR TITLE
Switch to RDF4J standalone ShaclValidator

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/validator/MetadataValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/metadata/validator/MetadataValidator.java
@@ -27,7 +27,7 @@ import org.fairdatateam.fairdatapoint.database.rdf.repository.MetadataRepository
 import org.fairdatateam.fairdatapoint.entity.exception.ValidationException;
 import org.fairdatateam.fairdatapoint.entity.resource.ResourceDefinition;
 import org.fairdatateam.fairdatapoint.service.metadata.exception.MetadataServiceException;
-import org.fairdatateam.fairdatapoint.service.rdf.ShaclValidator;
+import org.fairdatateam.fairdatapoint.service.rdf.StandaloneShaclValidator;
 import org.fairdatateam.fairdatapoint.service.resource.ResourceDefinitionService;
 import org.fairdatateam.fairdatapoint.service.schema.MetadataSchemaService;
 import org.eclipse.rdf4j.model.IRI;
@@ -49,7 +49,7 @@ public class MetadataValidator {
     private MetadataRepository metadataRepository;
 
     @Autowired
-    private ShaclValidator shaclValidator;
+    private StandaloneShaclValidator standaloneShaclValidator;
 
     @Autowired
     private MetadataSchemaService metadataSchemaService;
@@ -66,7 +66,7 @@ public class MetadataValidator {
 
     private void validateByShacl(Model metadata, IRI uri) {
         final Model shacl = metadataSchemaService.getShaclFromSchemas();
-        shaclValidator.validate(shacl, metadata, uri.stringValue());
+        standaloneShaclValidator.validate(shacl, metadata, uri.stringValue());
     }
 
     private void validateParent(Model metadata, ResourceDefinition definition) throws MetadataServiceException {

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidator.java
@@ -22,6 +22,7 @@
  */
 package org.fairdatateam.fairdatapoint.service.rdf;
 
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.shacl.ShaclValidator;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.StringWriter;
 
+@Slf4j
 @Service
 public class StandaloneShaclValidator {
 
@@ -55,11 +57,12 @@ public class StandaloneShaclValidator {
                 .withShapes(modelToString(shacl), baseUri, RDFFormat.TURTLE)
                 .build();
 
-        // ValidationReport is deprecated due to planned move to other package
+        // TODO: ValidationReport is deprecated due to planned move to other package
         // https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/sail/shacl/results/ValidationReport.html
         final ValidationReport report = validator.validate(modelToString(data), baseUri, RDFFormat.TURTLE);
 
         if (!report.conforms()) {
+            log.info("RDF validation failed: {}", report);
             throw new RdfValidationException(report.asModel());
         }
     }

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidator.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.i;
 
 @Service
-public class ShaclValidator {
+public class StandaloneShaclValidator {
 
     public void validate(Model shacl, Model data, String baseUri) {
         // 1. Prepare repository

--- a/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidator.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidator.java
@@ -22,55 +22,45 @@
  */
 package org.fairdatateam.fairdatapoint.service.rdf;
 
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.sail.shacl.ShaclValidator;
+import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.fairdatateam.fairdatapoint.entity.exception.RdfValidationException;
-import org.fairdatateam.fairdatapoint.entity.exception.ValidationException;
 import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.vocabulary.RDF4J;
-import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.eclipse.rdf4j.sail.shacl.ShaclSail;
-import org.eclipse.rdf4j.sail.shacl.ShaclSailValidationException;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-
-import static org.fairdatateam.fairdatapoint.util.ValueFactoryHelper.i;
+import java.io.StringWriter;
 
 @Service
 public class StandaloneShaclValidator {
 
+    /**
+     * Converts an RDF4J Model instance to a String, because  ShaclValidator.Builder.withShapes() does not accept Model.
+     */
+    private String modelToString(Model model) {
+        final StringWriter writer = new StringWriter();
+        Rio.write(model, writer, RDFFormat.TURTLE);
+        return writer.toString();
+    }
+
+    /**
+     * Uses a standalone ShaclValidator to validate <code>data</code> against <code>shacl</code>.
+     * Raises <code>RdfValidationException</code> if validation fails.
+     */
     public void validate(Model shacl, Model data, String baseUri) {
-        // 1. Prepare repository
-        final ShaclSail shaclSail = new ShaclSail(new MemoryStore());
-        shaclSail.setRdfsSubClassReasoning(true);
-        final SailRepository sailRepository = new SailRepository(shaclSail);
-        sailRepository.init();
+        // standalone ShaclValidator
+        final ShaclValidator.ValidatorWithShapes validator = ShaclValidator.builder()
+                .setRdfsSubClassReasoning(true)
+                .withShapes(modelToString(shacl), baseUri, RDFFormat.TURTLE)
+                .build();
 
-        try (SailRepositoryConnection connection = sailRepository.getConnection()) {
-            // 2. Save SHACL
-            connection.begin();
-            connection.add(shacl, RDF4J.SHACL_SHAPE_GRAPH);
-            connection.commit();
+        // ValidationReport is deprecated due to planned move to other package
+        // https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/sail/shacl/results/ValidationReport.html
+        final ValidationReport report = validator.validate(modelToString(data), baseUri, RDFFormat.TURTLE);
 
-            // 3. Validate data
-            connection.begin();
-            connection.add(new ArrayList<>(data), i(baseUri));
-            connection.commit();
-
-        }
-        catch (RepositoryException exception) {
-            final Throwable cause = exception.getCause();
-            if (cause instanceof ShaclSailValidationException) {
-                final Model validationReportModel =
-                        ((ShaclSailValidationException) cause).validationReportAsModel();
-                throw new RdfValidationException(validationReportModel);
-            }
-            throw new ValidationException("Validation failed (unsupported exception)");
-        }
-        finally {
-            sailRepository.shutDown();
+        if (!report.conforms()) {
+            throw new RdfValidationException(report.asModel());
         }
     }
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/WebIntegrationTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/WebIntegrationTest.java
@@ -24,12 +24,14 @@ package org.fairdatateam.fairdatapoint;
 
 import org.fairdatateam.fairdatapoint.database.mongo.migration.development.MigrationRunner;
 import org.fairdatateam.fairdatapoint.database.rdf.migration.development.RdfDevelopmentMigrationRunner;
+import org.fairdatateam.fairdatapoint.service.rdf.StandaloneShaclValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles(Profiles.TESTING)
 // todo: in most cases we can probably use WebEnvironment.MOCK with MockMvc instead of TestRestTemplate (see #862)
@@ -57,6 +59,9 @@ public abstract class WebIntegrationTest {
 
     @Autowired
     protected RdfDevelopmentMigrationRunner rdfDevelopmentMigrationRunner;
+
+    @MockitoBean
+    StandaloneShaclValidator shaclValidator;
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
@@ -92,7 +92,7 @@ public class StandaloneShaclValidatorTest {
         // given rdf data that does not match the shacl shape
         final Model invalidData = Rio.parse(new StringReader(DATA_INVALID), BASE_URI, RDFFormat.TURTLE);
 
-        // an exception is raised
+        // a validation exception is raised
         RdfValidationException exception = assertThrows(RdfValidationException.class,
                 () -> standaloneShaclValidator.validate(shaclSchema, invalidData, BASE_URI));
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
@@ -30,7 +30,7 @@ import org.fairdatateam.fairdatapoint.entity.exception.RdfValidationException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.io.Reader;
+import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -75,13 +75,13 @@ public class StandaloneShaclValidatorTest {
      */
     public StandaloneShaclValidatorTest() throws IOException {
         this.standaloneShaclValidator = new StandaloneShaclValidator();
-        this.shaclSchema = Rio.parse(Reader.of(SHACL_SCHEMA), BASE_URI, RDFFormat.TURTLE);
+        this.shaclSchema = Rio.parse(new StringReader(SHACL_SCHEMA), BASE_URI, RDFFormat.TURTLE);
     }
 
     @Test
     public void validDataPassesValidation() throws IOException {
         // given rdf data matching the shacl shape
-        final Model validData = Rio.parse(Reader.of(DATA_VALID), BASE_URI, RDFFormat.TURTLE);
+        final Model validData = Rio.parse(new StringReader(DATA_VALID), BASE_URI, RDFFormat.TURTLE);
 
         // validation succeeds
         standaloneShaclValidator.validate(shaclSchema, validData, BASE_URI);
@@ -90,7 +90,7 @@ public class StandaloneShaclValidatorTest {
     @Test
     public void invalidDataCausesValidationException() throws IOException {
         // given rdf data that does not match the shacl shape
-        final Model invalidData = Rio.parse(Reader.of(DATA_INVALID), BASE_URI, RDFFormat.TURTLE);
+        final Model invalidData = Rio.parse(new StringReader(DATA_INVALID), BASE_URI, RDFFormat.TURTLE);
 
         // an exception is raised
         RdfValidationException exception = assertThrows(RdfValidationException.class,

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.io.StringWriter;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/service/rdf/StandaloneShaclValidatorTest.java
@@ -1,0 +1,104 @@
+/**
+ * The MIT License
+ * Copyright © 2017 FAIR Data Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.fairdatateam.fairdatapoint.service.rdf;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.fairdatateam.fairdatapoint.entity.exception.RdfValidationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StandaloneShaclValidatorTest {
+
+    private static final String BASE_URI = "";
+
+    private static final String SHACL_SCHEMA = """
+            @prefix dcat: <http://www.w3.org/ns/dcat#> .
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            
+            [] a sh:NodeShape ;
+              sh:targetClass dcat:Resource ;
+              sh:property [
+                sh:path dcat:version ;
+                sh:nodeKind sh:Literal ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+              ] .
+            """;
+
+    private static final String DATA_VALID = """
+            @prefix dcat: <http://www.w3.org/ns/dcat#> .
+            
+            <http://fdp.example.org> a dcat:Resource ;
+              dcat:version "1.0" .
+            """;
+
+    private static final String DATA_INVALID = """
+            @prefix dcat: <http://www.w3.org/ns/dcat#> .
+            
+            <http://fdp.example.org> a dcat:Resource .
+            """;
+
+    private final Model shaclSchema;
+
+
+    private final StandaloneShaclValidator standaloneShaclValidator;
+
+    /**
+     * Constructor (not a spring test, so no autowiring)
+     */
+    public StandaloneShaclValidatorTest() throws IOException {
+        this.standaloneShaclValidator = new StandaloneShaclValidator();
+        this.shaclSchema = Rio.parse(Reader.of(SHACL_SCHEMA), BASE_URI, RDFFormat.TURTLE);
+    }
+
+    @Test
+    public void validDataPassesValidation() throws IOException {
+        // given rdf data matching the shacl shape
+        final Model validData = Rio.parse(Reader.of(DATA_VALID), BASE_URI, RDFFormat.TURTLE);
+
+        // validation succeeds
+        standaloneShaclValidator.validate(shaclSchema, validData, BASE_URI);
+    }
+
+    @Test
+    public void invalidDataCausesValidationException() throws IOException {
+        // given rdf data that does not match the shacl shape
+        final Model invalidData = Rio.parse(Reader.of(DATA_INVALID), BASE_URI, RDFFormat.TURTLE);
+
+        // an exception is raised
+        RdfValidationException exception = assertThrows(RdfValidationException.class,
+                () -> standaloneShaclValidator.validate(shaclSchema, invalidData, BASE_URI));
+
+        // the exception contains a validation report indicating the cause of failure
+        final Model validationReportModel = exception.getModel();
+        assertTrue(validationReportModel.contains(null, SHACL.MIN_COUNT, null));
+    }
+}


### PR DESCRIPTION
- Switched from custom `ShaclSail`-based in-memory shacl validator to a standalone RDF4J `ShaclValidator.ValidatorWithShapes`, following the [RDF4J SHACL validation docs]. The default RDF4J `ValidatorWithShapes` implementation is more reliable and a bit more efficient than the original custom implementation.

- Mocked the validator in `WebIntegrationTest`, because we already know whether our test fixtures are correct or not. This fixes #862 (at least partially). 

- Added dedicated tests for our `StandaloneShaclValidator` implementation.

>[!NOTE]
>There is still room for improvement in terms of efficiency, because the SHACL schemas are still loaded for every `validate()` call. It should be possible to cache the validator for a given set of SHACL schemas. The validator should only need updating whenever the schemas change, which hardly ever happens. However, we'll leave this for later, because caching would introduce a lot more complexity.


[RDF4J SHACL validation docs]: https://rdf4j.org/documentation/programming/shacl/#standalone-validation-with-shaclvalidator