### PR TITLE
Clean up aclRepository autowiring

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,4 @@
 config.stopBubbling = true
+
+# Ensure @Qualifier annotations are copied to lombok generated constructor arguments
 lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/java/org/fairdatateam/fairdatapoint/migration/mongodb/development/AclMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/migration/mongodb/development/AclMigration.java
@@ -22,6 +22,7 @@
  */
 package org.fairdatateam.fairdatapoint.migration.mongodb.development;
 
+import lombok.RequiredArgsConstructor;
 import org.fairdatateam.fairdatapoint.migration.Migration;
 import org.fairdatateam.fairdatapoint.rdf.metadata.Metadata;
 import org.fairdatateam.fairdatapoint.security.membership.MemberService;
@@ -36,10 +37,12 @@ import org.springframework.stereotype.Service;
 import static java.lang.String.format;
 
 @Service
+@RequiredArgsConstructor
 public class AclMigration implements Migration {
 
     private final AclCache aclCache;
 
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
     private final AclRepository aclRepository;
 
     private final MemberService memberService;
@@ -48,31 +51,10 @@ public class AclMigration implements Migration {
 
     private final MongoAuthenticationService mongoAuthenticationService;
 
+    @Qualifier("persistentUrl")
     private final String persistentUrl;
 
     private final UserFixtures userFixtures;
-
-    /**
-     * Constructor (autowired)
-     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
-     */
-    public AclMigration(
-            AclCache aclCache,
-            AclRepository aclRepository,
-            MemberService memberService,
-            MembershipFixtures membershipFixtures,
-            MongoAuthenticationService mongoAuthenticationService,
-            @Qualifier("persistentUrl") String persistentUrl,
-            UserFixtures userFixtures
-    ) {
-        this.aclCache = aclCache;
-        this.aclRepository = aclRepository;
-        this.memberService = memberService;
-        this.membershipFixtures = membershipFixtures;
-        this.mongoAuthenticationService = mongoAuthenticationService;
-        this.persistentUrl = persistentUrl;
-        this.userFixtures = userFixtures;
-    }
 
     public void runMigration() {
         aclRepository.deleteAll();

--- a/src/main/java/org/fairdatateam/fairdatapoint/migration/mongodb/development/AclMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/migration/mongodb/development/AclMigration.java
@@ -26,7 +26,6 @@ import org.fairdatateam.fairdatapoint.migration.Migration;
 import org.fairdatateam.fairdatapoint.rdf.metadata.Metadata;
 import org.fairdatateam.fairdatapoint.security.membership.MemberService;
 import org.fairdatateam.fairdatapoint.security.auth.MongoAuthenticationService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.fairdatateam.security.acls.dao.AclRepository;
 import org.springframework.security.acls.model.AclCache;
@@ -39,27 +38,41 @@ import static java.lang.String.format;
 @Service
 public class AclMigration implements Migration {
 
-    @Autowired
-    @Qualifier("persistentUrl")
-    private String persistentUrl;
+    private final AclCache aclCache;
 
-    @Autowired
-    private UserFixtures userFixtures;
+    private final AclRepository aclRepository;
 
-    @Autowired
-    private MembershipFixtures membershipFixtures;
+    private final MemberService memberService;
 
-    @Autowired
-    private AclRepository aclRepository;
+    private final MembershipFixtures membershipFixtures;
 
-    @Autowired
-    private MemberService memberService;
+    private final MongoAuthenticationService mongoAuthenticationService;
 
-    @Autowired
-    private MongoAuthenticationService mongoAuthenticationService;
+    private final String persistentUrl;
 
-    @Autowired
-    private AclCache aclCache;
+    private final UserFixtures userFixtures;
+
+    /**
+     * Constructor (autowired)
+     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
+     */
+    public AclMigration(
+            AclCache aclCache,
+            AclRepository aclRepository,
+            MemberService memberService,
+            MembershipFixtures membershipFixtures,
+            MongoAuthenticationService mongoAuthenticationService,
+            @Qualifier("persistentUrl") String persistentUrl,
+            UserFixtures userFixtures
+    ) {
+        this.aclCache = aclCache;
+        this.aclRepository = aclRepository;
+        this.memberService = memberService;
+        this.membershipFixtures = membershipFixtures;
+        this.mongoAuthenticationService = mongoAuthenticationService;
+        this.persistentUrl = persistentUrl;
+        this.userFixtures = userFixtures;
+    }
 
     public void runMigration() {
         aclRepository.deleteAll();

--- a/src/main/java/org/fairdatateam/fairdatapoint/migration/mongodb/development/AclMigration.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/migration/mongodb/development/AclMigration.java
@@ -42,7 +42,7 @@ public class AclMigration implements Migration {
 
     private final AclCache aclCache;
 
-    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection (bean is created in external dependency) */
     private final AclRepository aclRepository;
 
     private final MemberService memberService;

--- a/src/main/java/org/fairdatateam/fairdatapoint/reset/ResetService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/reset/ResetService.java
@@ -66,7 +66,7 @@ public class ResetService {
 
     private final AclCache aclCache;
 
-    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection (bean is created in external dependency) */
     private final AclRepository aclRepository;
 
     private final ApiKeyRepository apiKeyRepository;

--- a/src/main/java/org/fairdatateam/fairdatapoint/reset/ResetService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/reset/ResetService.java
@@ -42,7 +42,6 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.fairdatateam.fairdatapoint.user.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -60,60 +59,84 @@ import static org.fairdatateam.fairdatapoint.common.util.ValueFactoryHelper.i;
 @Service
 public class ResetService {
 
-    @Autowired
-    @Qualifier("persistentUrl")
-    private String persistentUrl;
-
     @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
 
-    @Autowired
-    private IRI license;
+    private final AclCache aclCache;
 
-    @Autowired
-    private IRI language;
+    private final AclRepository aclRepository;
 
-    @Autowired
-    private Repository repository;
+    private final ApiKeyRepository apiKeyRepository;
 
-    @Autowired
-    private ApiKeyRepository apiKeyRepository;
+    private final GenericMetadataService genericMetadataService;
 
-    @Autowired
-    private MembershipRepository membershipRepository;
+    private final IRI language;
 
-    @Autowired
-    private AclRepository aclRepository;
+    private final IRI license;
 
-    @Autowired
-    private AclCache aclCache;
+    private final MembershipRepository membershipRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final MetadataRepository metadataRepository;
 
-    @Autowired
-    private MetadataSchemaRepository metadataSchemaRepository;
+    private final MetadataSchemaRepository metadataSchemaRepository;
 
-    @Autowired
-    private ResourceDefinitionRepository resourceDefinitionRepository;
+    private final MongoTemplate mongoTemplate;
 
-    @Autowired
-    private ResourceDefinitionCache resourceDefinitionCache;
+    private final String persistentUrl;
 
-    @Autowired
-    private ResourceDefinitionTargetClassesCache resourceDefinitionTargetClassesCache;
+    private final Repository repository;
 
-    @Autowired
-    private MetadataRepository metadataRepository;
+    private final ResourceDefinitionCache resourceDefinitionCache;
 
-    @Autowired
-    private GenericMetadataService genericMetadataService;
+    private final ResourceDefinitionRepository resourceDefinitionRepository;
 
-    @Autowired
-    private SettingsService settingsService;
+    private final ResourceDefinitionTargetClassesCache resourceDefinitionTargetClassesCache;
 
-    @Autowired
-    private MongoTemplate mongoTemplate;
+    private final SettingsService settingsService;
+
+    private final UserRepository userRepository;
+
+    /**
+     * Constructor (autowired)
+     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
+     */
+    public ResetService(
+            AclCache aclCache,
+            AclRepository aclRepository,
+            ApiKeyRepository apiKeyRepository,
+            GenericMetadataService genericMetadataService,
+            IRI language,
+            IRI license,
+            MembershipRepository membershipRepository,
+            MetadataRepository metadataRepository,
+            MetadataSchemaRepository metadataSchemaRepository,
+            MongoTemplate mongoTemplate,
+            @Qualifier("persistentUrl") String persistentUrl,
+            Repository repository,
+            ResourceDefinitionCache resourceDefinitionCache,
+            ResourceDefinitionRepository resourceDefinitionRepository,
+            ResourceDefinitionTargetClassesCache resourceDefinitionTargetClassesCache,
+            SettingsService settingsService,
+            UserRepository userRepository
+    ) {
+        this.aclCache = aclCache;
+        this.aclRepository = aclRepository;
+        this.apiKeyRepository = apiKeyRepository;
+        this.genericMetadataService = genericMetadataService;
+        this.language = language;
+        this.license = license;
+        this.membershipRepository = membershipRepository;
+        this.metadataRepository = metadataRepository;
+        this.metadataSchemaRepository = metadataSchemaRepository;
+        this.mongoTemplate = mongoTemplate;
+        this.persistentUrl = persistentUrl;
+        this.repository = repository;
+        this.resourceDefinitionCache = resourceDefinitionCache;
+        this.resourceDefinitionRepository = resourceDefinitionRepository;
+        this.resourceDefinitionTargetClassesCache = resourceDefinitionTargetClassesCache;
+        this.settingsService = settingsService;
+        this.userRepository = userRepository;
+    }
 
     @PreAuthorize("hasRole('ADMIN')")
     public void resetToFactoryDefaults(ResetDTO reqDto) throws Exception {

--- a/src/main/java/org/fairdatateam/fairdatapoint/reset/ResetService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/reset/ResetService.java
@@ -23,6 +23,7 @@
 package org.fairdatateam.fairdatapoint.reset;
 
 import com.mongodb.client.MongoCollection;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.fairdatateam.fairdatapoint.rdf.metadata.MetadataRepository;
 import org.fairdatateam.fairdatapoint.resource.ResourceDefinition;
@@ -57,6 +58,7 @@ import static org.fairdatateam.fairdatapoint.common.util.ValueFactoryHelper.i;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ResetService {
 
     @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
@@ -64,6 +66,7 @@ public class ResetService {
 
     private final AclCache aclCache;
 
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
     private final AclRepository aclRepository;
 
     private final ApiKeyRepository apiKeyRepository;
@@ -82,6 +85,7 @@ public class ResetService {
 
     private final MongoTemplate mongoTemplate;
 
+    @Qualifier("persistentUrl")
     private final String persistentUrl;
 
     private final Repository repository;
@@ -95,48 +99,6 @@ public class ResetService {
     private final SettingsService settingsService;
 
     private final UserRepository userRepository;
-
-    /**
-     * Constructor (autowired)
-     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
-     */
-    public ResetService(
-            AclCache aclCache,
-            AclRepository aclRepository,
-            ApiKeyRepository apiKeyRepository,
-            GenericMetadataService genericMetadataService,
-            IRI language,
-            IRI license,
-            MembershipRepository membershipRepository,
-            MetadataRepository metadataRepository,
-            MetadataSchemaRepository metadataSchemaRepository,
-            MongoTemplate mongoTemplate,
-            @Qualifier("persistentUrl") String persistentUrl,
-            Repository repository,
-            ResourceDefinitionCache resourceDefinitionCache,
-            ResourceDefinitionRepository resourceDefinitionRepository,
-            ResourceDefinitionTargetClassesCache resourceDefinitionTargetClassesCache,
-            SettingsService settingsService,
-            UserRepository userRepository
-    ) {
-        this.aclCache = aclCache;
-        this.aclRepository = aclRepository;
-        this.apiKeyRepository = apiKeyRepository;
-        this.genericMetadataService = genericMetadataService;
-        this.language = language;
-        this.license = license;
-        this.membershipRepository = membershipRepository;
-        this.metadataRepository = metadataRepository;
-        this.metadataSchemaRepository = metadataSchemaRepository;
-        this.mongoTemplate = mongoTemplate;
-        this.persistentUrl = persistentUrl;
-        this.repository = repository;
-        this.resourceDefinitionCache = resourceDefinitionCache;
-        this.resourceDefinitionRepository = resourceDefinitionRepository;
-        this.resourceDefinitionTargetClassesCache = resourceDefinitionTargetClassesCache;
-        this.settingsService = settingsService;
-        this.userRepository = userRepository;
-    }
 
     @PreAuthorize("hasRole('ADMIN')")
     public void resetToFactoryDefaults(ResetDTO reqDto) throws Exception {

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -23,7 +23,6 @@
 package org.fairdatateam.fairdatapoint.security.acl;
 
 import org.fairdatateam.fairdatapoint.user.UserRole;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
@@ -50,11 +49,16 @@ public class AclConfig {
 
     public static final String ACL_CACHE = "ACL_CACHE";
 
-    @Autowired
-    private MongoTemplate mongoTemplate;
+    private final AclRepository aclRepository;
 
-    @Autowired
-    private AclRepository aclRepository;
+    private final MongoTemplate mongoTemplate;
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    public AclConfig(AclRepository aclRepository, MongoTemplate mongoTemplate) {
+        this.aclRepository = aclRepository;
+        this.mongoTemplate = mongoTemplate;
+    }
+
 
     @Bean
     public AclCache aclCache(ConcurrentMapCacheManager cacheManager) {

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -55,7 +55,7 @@ public class AclConfig {
 
     /**
      * Constructor (autowired)
-     * @noinspection SpringJavaInjectionPointsAutowiringInspection
+     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
      */
     public AclConfig(AclRepository aclRepository, MongoTemplate mongoTemplate) {
         this.aclRepository = aclRepository;

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -22,6 +22,7 @@
  */
 package org.fairdatateam.fairdatapoint.security.acl;
 
+import lombok.RequiredArgsConstructor;
 import org.fairdatateam.fairdatapoint.user.UserRole;
 import org.springframework.cache.Cache;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -45,22 +46,15 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import static java.lang.String.format;
 
 @Configuration
+@RequiredArgsConstructor
 public class AclConfig {
 
     public static final String ACL_CACHE = "ACL_CACHE";
 
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
     private final AclRepository aclRepository;
 
     private final MongoTemplate mongoTemplate;
-
-    /**
-     * Constructor (autowired)
-     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
-     */
-    public AclConfig(AclRepository aclRepository, MongoTemplate mongoTemplate) {
-        this.aclRepository = aclRepository;
-        this.mongoTemplate = mongoTemplate;
-    }
 
     @Bean
     public AclCache aclCache(ConcurrentMapCacheManager cacheManager) {

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -76,7 +76,7 @@ public class AclConfig {
 
     @Bean
     public AclAuthorizationStrategy aclAuthorizationStrategy() {
-        return new AclAuthorizationStrategyImpl(new SimpleGrantedAuthority(format("ROLE_%s", UserRole.ADMIN)));
+        return new AclAuthorizationStrategyImpl(new SimpleGrantedAuthority(format("ROLE_%s", UserRole.ADMIN.name())));
     }
 
     @Bean

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -51,7 +51,7 @@ public class AclConfig {
 
     public static final String ACL_CACHE = "ACL_CACHE";
 
-    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection (bean is created in external dependency) */
     private final AclRepository aclRepository;
 
     private final MongoTemplate mongoTemplate;

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -82,9 +82,7 @@ public class AclConfig {
 
     @Bean
     public AclAuthorizationStrategy aclAuthorizationStrategy() {
-        return new AclAuthorizationStrategyImpl(new SimpleGrantedAuthority(
-                format("ROLE_%s", UserRole.ADMIN.toString()))
-        );
+        return new AclAuthorizationStrategyImpl(new SimpleGrantedAuthority(format("ROLE_%s", UserRole.ADMIN)));
     }
 
     @Bean

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/acl/AclConfig.java
@@ -53,12 +53,14 @@ public class AclConfig {
 
     private final MongoTemplate mongoTemplate;
 
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    /**
+     * Constructor (autowired)
+     * @noinspection SpringJavaInjectionPointsAutowiringInspection
+     */
     public AclConfig(AclRepository aclRepository, MongoTemplate mongoTemplate) {
         this.aclRepository = aclRepository;
         this.mongoTemplate = mongoTemplate;
     }
-
 
     @Bean
     public AclCache aclCache(ConcurrentMapCacheManager cacheManager) {

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
 
     private final AclCache aclCache;
 
-    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection (bean is created in external dependency) */
     private final AclRepository aclRepository;
 
     private final CurrentUserProvider currentUserProvider;

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
@@ -22,6 +22,7 @@
  */
 package org.fairdatateam.fairdatapoint.security.membership;
 
+import lombok.RequiredArgsConstructor;
 import org.fairdatateam.fairdatapoint.user.UserRepository;
 import org.fairdatateam.fairdatapoint.common.error.ValidationException;
 import org.fairdatateam.fairdatapoint.user.User;
@@ -41,10 +42,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
 
     private final AclCache aclCache;
 
+    /** @noinspection SpringJavaInjectionPointsAutowiringInspection */
     private final AclRepository aclRepository;
 
     private final CurrentUserProvider currentUserProvider;
@@ -58,30 +61,6 @@ public class MemberService {
     private final PermissionService permissionService;
 
     private final UserRepository userRepository;
-
-    /**
-     * Constructor (autowired)
-     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
-     */
-    public MemberService(
-            AclCache aclCache,
-            AclRepository aclRepository,
-            CurrentUserProvider currentUserProvider,
-            MemberMapper memberMapper,
-            MembershipRepository membershipRepository,
-            MutableAclService aclService,
-            PermissionService permissionService,
-            UserRepository userRepository
-    ) {
-        this.aclCache = aclCache;
-        this.aclRepository = aclRepository;
-        this.currentUserProvider = currentUserProvider;
-        this.memberMapper = memberMapper;
-        this.membershipRepository = membershipRepository;
-        this.aclService = aclService;
-        this.permissionService = permissionService;
-        this.userRepository = userRepository;
-    }
 
     @PreAuthorize("hasPermission(#entityId, #entityType.getName(), 'WRITE') or hasRole('ADMIN')")
     public <T> List<MemberDTO> getMembers(String entityId, Class<T> entityType) {

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
@@ -61,7 +61,7 @@ public class MemberService {
 
     /**
      * Constructor (autowired)
-     * @noinspection SpringJavaInjectionPointsAutowiringInspection
+     * @noinspection SpringJavaInjectionPointsAutowiringInspection (only for aclRepository)
      */
     public MemberService(
             AclCache aclCache,

--- a/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/security/membership/MemberService.java
@@ -27,7 +27,6 @@ import org.fairdatateam.fairdatapoint.common.error.ValidationException;
 import org.fairdatateam.fairdatapoint.user.User;
 import org.fairdatateam.fairdatapoint.user.UserRole;
 import org.fairdatateam.fairdatapoint.security.CurrentUserProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.fairdatateam.security.acls.dao.AclRepository;
 import org.springframework.security.acls.domain.BasePermission;
@@ -44,29 +43,45 @@ import java.util.stream.Collectors;
 @Service
 public class MemberService {
 
-    @Autowired
-    private MutableAclService aclService;
+    private final AclCache aclCache;
 
-    @Autowired
-    private MembershipRepository membershipRepository;
+    private final AclRepository aclRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
 
-    @Autowired
-    private CurrentUserProvider currentUserProvider;
+    private final MemberMapper memberMapper;
 
-    @Autowired
-    private PermissionService permissionService;
+    private final MembershipRepository membershipRepository;
 
-    @Autowired
-    private MemberMapper memberMapper;
+    private final MutableAclService aclService;
 
-    @Autowired
-    private AclRepository aclRepository;
+    private final PermissionService permissionService;
 
-    @Autowired
-    private AclCache aclCache;
+    private final UserRepository userRepository;
+
+    /**
+     * Constructor (autowired)
+     * @noinspection SpringJavaInjectionPointsAutowiringInspection
+     */
+    public MemberService(
+            AclCache aclCache,
+            AclRepository aclRepository,
+            CurrentUserProvider currentUserProvider,
+            MemberMapper memberMapper,
+            MembershipRepository membershipRepository,
+            MutableAclService aclService,
+            PermissionService permissionService,
+            UserRepository userRepository
+    ) {
+        this.aclCache = aclCache;
+        this.aclRepository = aclRepository;
+        this.currentUserProvider = currentUserProvider;
+        this.memberMapper = memberMapper;
+        this.membershipRepository = membershipRepository;
+        this.aclService = aclService;
+        this.permissionService = permissionService;
+        this.userRepository = userRepository;
+    }
 
     @PreAuthorize("hasPermission(#entityId, #entityType.getName(), 'WRITE') or hasRole('ADMIN')")
     public <T> List<MemberDTO> getMembers(String entityId, Class<T> entityType) {

--- a/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/List_POST.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/acceptance/metadata/catalog/List_POST.java
@@ -52,15 +52,6 @@ public class List_POST extends WebIntegrationTest {
     @Autowired
     private TestRdfMetadataFixtures testMetadataFixtures;
 
-    @Autowired
-    private AclRepository aclRepository;
-
-    @Autowired
-    private AclCache aclCache;
-
-    @Autowired
-    private RdfMetadataMigration rdfMetadataMigration;
-
     private URI url() {
         return URI.create("/catalog");
     }


### PR DESCRIPTION
Applied the following changes to `AclConfig`, `ResetService`, `MemberService`, and `AclMigration`:

- constructor autowiring with the help of lombok's `@RequiredArgsConstructor`
- suppress intellij static analysis warnings for `aclRepository` bean from external dependency
  (note that inline `//noinspection ...` does not work, but `/** @noinspection ... */` does)
- remove redundant `toString` call