### PR TITLE
Remove ancient FDPMetadata reference from FactoryDefaults and mongodb

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/reset/FactoryDefaults.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/reset/FactoryDefaults.java
@@ -404,6 +404,7 @@ public class FactoryDefaults {
                 .append("isPrincipal", true);
         final Document acl = new Document();
         // TODO: there is no FDPMetadata class. This was already removed in 2020 (c37890f)
+        // FDPMetadata is actually defined in an old external repo https://github.com/FAIRDataTeam/fairmetadata4j
         acl.append("className", "org.fairdatateam.fairdatapoint.entity.metadata.FDPMetadata");
         acl.append("instanceId", persistentUrl);
         acl.append("owner", owner);

--- a/src/main/java/org/fairdatateam/fairdatapoint/reset/FactoryDefaults.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/reset/FactoryDefaults.java
@@ -403,9 +403,7 @@ public class FactoryDefaults {
                 .append("name", USER_ALBERT.getUuid())
                 .append("isPrincipal", true);
         final Document acl = new Document();
-        // TODO: there is no FDPMetadata class. This was already removed in 2020 (c37890f)
-        // FDPMetadata is actually defined in an old external repo https://github.com/FAIRDataTeam/fairmetadata4j
-        acl.append("className", "org.fairdatateam.fairdatapoint.entity.metadata.FDPMetadata");
+        acl.append("className", "org.fairdatateam.fairdatapoint.rdf.metadata.Metadata");
         acl.append("instanceId", persistentUrl);
         acl.append("owner", owner);
         acl.append("inheritPermissions", true);


### PR DESCRIPTION
todo:

- [x] figure out the desired value for `className` and fix the `FactoryDefaults` accordingly -> Changed to `Metadata` following mongodb migration 0002
- [x] create a data migration to fix this in existing deployments -> Turns out there already is a migration that does this, viz. mongo migration 0002, but in a fresh deployment, this migration runs ***before*** the `FactoryDefaults` are applied. This is because RDF triple-store migration 0001 uses `FactoryDefaults` from the app code, making it immutable, and because the RDF migrations only run after all mongodb migrations have finished.