### PR TITLE
Catalog page endpoint response on service outage 

### DIFF
--- a/src/main/java/org/fairdatateam/fairdatapoint/rdf/metadata/AbstractMetadataRdfRepository.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/rdf/metadata/AbstractMetadataRdfRepository.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.repository.Repository;
@@ -48,6 +49,7 @@ public abstract class AbstractMetadataRdfRepository implements MetadataRdfReposi
     private static final String MSG_ERROR_REMOVE_ALL = "Error remove all: ";
     private static final String MSG_ERROR_EXISTS = "Error check statement existence: ";
     private static final String MSG_ERROR_SAVE = "Error storing statements: ";
+    private static final String MSG_ERROR_QUERY = "Error evaluating SPARQL query: ";
 
     private static final String FIELD_CHILD = "child";
     private static final String FIELD_TITLE = "title";
@@ -147,6 +149,12 @@ public abstract class AbstractMetadataRdfRepository implements MetadataRdfReposi
         }
         catch (RepositoryException exception) {
             throw new MetadataRdfRepositoryException(MSG_ERROR_URI + exception.getMessage());
+        }
+        catch (QueryEvaluationException exception) {
+            // Thrown when the query fails to execute against the triple store (e.g. it is
+            // unreachable mid-query), not when the query text itself is malformed - treat it
+            // as a repository/infrastructure failure rather than a client error.
+            throw new MetadataRdfRepositoryException(MSG_ERROR_QUERY + exception.getMessage());
         }
     }
 

--- a/src/main/java/org/fairdatateam/fairdatapoint/rdf/metadata/GenericController.java
+++ b/src/main/java/org/fairdatateam/fairdatapoint/rdf/metadata/GenericController.java
@@ -375,10 +375,9 @@ public class GenericController {
 
                 // 4.3 Retrieve children metadata only for requested page
                 final int childrenCount = children.size();
-                children.stream().skip((long) page * size).limit(size)
-                        .map(childUri -> retrieveChildModel(childMetadataService, childUri))
-                        .flatMap(Optional::stream)
-                        .forEach(resultRdf::addAll);
+                for (Value childUri : children.stream().skip((long) page * size).limit(size).toList()) {
+                    resultRdf.addAll(childMetadataService.retrieve(i(childUri.stringValue())));
+                }
 
                 // 4.4 Set Link headers and send response
                 final HttpHeaders responseHeaders = new HttpHeaders();
@@ -427,16 +426,6 @@ public class GenericController {
         }
 
         return String.join(", ", links);
-    }
-
-    private Optional<Model> retrieveChildModel(MetadataService childMetadataService, Value childUri) {
-        try {
-            final Model childModel = childMetadataService.retrieve(i(childUri.stringValue()));
-            return Optional.of(childModel);
-        }
-        catch (MetadataServiceException exception) {
-            return Optional.empty();
-        }
     }
 
     private String createLink(String entityUrl, String childPrefix, int page, int size, String rel) {

--- a/src/test/java/org/fairdatateam/fairdatapoint/rdf/metadata/GenericMetadataRdfRepositoryFailureTest.java
+++ b/src/test/java/org/fairdatateam/fairdatapoint/rdf/metadata/GenericMetadataRdfRepositoryFailureTest.java
@@ -1,0 +1,77 @@
+/**
+ * The MIT License
+ * Copyright © 2017 FAIR Data Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.fairdatateam.fairdatapoint.rdf.metadata;
+
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the triple store outage scenario: a query that fails while it is being
+ * evaluated (e.g. the store becomes unreachable mid-request) must be reported as a repository
+ * failure, not left as an unchecked exception that gets misclassified further up the stack.
+ */
+@ExtendWith(MockitoExtension.class)
+public class GenericMetadataRdfRepositoryFailureTest {
+
+    @Mock
+    private Repository repository;
+
+    @Mock
+    private RepositoryConnection connection;
+
+    @Mock
+    private TupleQuery query;
+
+    private GenericMetadataRdfRepository metadataRepository;
+
+    @BeforeEach
+    public void setUp() {
+        metadataRepository = new GenericMetadataRdfRepository(new ConcurrentMapCacheManager(), repository);
+    }
+
+    @Test
+    public void runSparqlQueryWrapsQueryEvaluationExceptionAsRepositoryException() {
+        // GIVEN: the triple store fails while the query is being evaluated
+        when(repository.getConnection()).thenReturn(connection);
+        when(connection.prepareTupleQuery(anyString())).thenReturn(query);
+        when(query.evaluate()).thenThrow(new QueryEvaluationException("Connection refused"));
+
+        // WHEN/THEN:
+        assertThrows(
+                MetadataRdfRepositoryException.class,
+                () -> metadataRepository.runSparqlQuery("SELECT * WHERE { ?s ?p ?o }", null)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Propagate triple store failures instead of returning empty results

## Related issue

fixes #978

## Details
When the underlying triple store is temporarily unreachable, the catalog child-listing endpoint (GET .../page/{childPrefix}) and SPARQL query execution were silently swallowing the failure and returning an empty, 200 OK result — indistinguishable from "no children exist." This caused external harvesters (e.g. CKAN) to interpret the outage as mass deletion, and the resulting inconsistency didn't self-heal once the store recovered.

## Changes

* `GenericController.getMetaDataChildren`: removed the `retrieveChildModel` try/catch that converted a failed child lookup into `Optional.empty()`. The failure now propagates as MetadataServiceException → 500.
* `AbstractMetadataRdfRepository.runSparqlQuery`: now also catches `QueryEvaluationException` (previously only `RepositoryException`), wrapping it into `MetadataRdfRepositoryException` so it's treated as an infrastructure failure (`500`) instead of being misclassified as a malformed query (400).


## Tests

* Added `GenericMetadataRdfRepositoryFailureTest` covering the `QueryEvaluationException` wrapping. 

## Manual testing
* Spin up the FDP from `main`, pointed at a running GraphDB container instead of the default embedded in-memory store.
* Call `GET /catalog/catalog-1/page/dataset` → confirm `200 OK` with the seeded dataset(s) in the body.
* Stop the GraphDB container (`docker stop <container>`) while FDP keeps running.
* Call the same endpoint again → **bug**: still `200 OK`, but now with an empty body — no error, no indication anything is wrong.
* Spin up the FDP from this branch, pointed at a fresh GraphDB container (restart it).
* Call `GET /catalog/catalog-1/page/dataset` → confirm `200 OK` with the seeded dataset(s), same as before.
* Stop the GraphDB container again while FDP keeps running.
* Call the same endpoint again → **fixed**: `500 Internal Server Error` instead of a false-empty `200`, correctly signaling the outage instead of silently implying the datasets were deleted.
