### PR TITLE
Skip secrets-dependent github workflows on forks

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,8 @@ jobs:
     # Nevertheless, it does provide extra verification for the release case as well.
     needs: publish
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository
+    if: github.repository == 'FAIRDataTeam/FAIRDataPoint'
     steps:
       - name: determine docker image version from ref_name
         # We need to remove the leading "v" from version strings like "v1.2.3", but not from tags like "very-nice".

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,6 +55,8 @@ jobs:
   snyk:
     name: Snyk (Maven)
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository
+    if: github.repository == 'FAIRDataTeam/FAIRDataPoint'
     permissions:
       actions: read
       contents: read
@@ -75,6 +77,7 @@ jobs:
   snyk-docker:
     name: Snyk (Docker)
     runs-on: ubuntu-latest
+    if: github.repository == 'FAIRDataTeam/FAIRDataPoint'
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
The following workflow or jobs are skipped when running on a fork, because they require credentials specific to `FAIRDataTeam`:

- `security.yml`
  - `snyk` job 
  - `snyk-docker` job 
- `docker-publish.yml`
  - `e2e`  job 
  - `publish` job (via [FAIRDataTeam/github-workflows#v3.3.0] which is picked up automatically)

[FAIRDataTeam/github-workflows#v3.3.0]: https://github.com/FAIRDataTeam/github-workflows/releases/tag/v3.3.0
