### PR TITLE
Switch to JRE base image and apk upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,12 @@
 version: 2
 updates:
   - package-ecosystem: "maven"
-    # Look for `requirements.*` files in the `root` directory
+    # Where to look for the pom.xml
     directory: "/"
-    # Check the registry for updates every week
+    # How often to check the registry for updates
     schedule:
       interval: "daily"
-    # Add labels to generated PRs
+    # Which labels to add to generated PRs
     labels:
       - "dependencies"
     # Group minor updates and patch updates, except for spring-boot-starter-parent updates,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,9 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    allow:
+      # don't do major upgrades
+      - dependency-name: "eclipse-temurin:*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests -Drevisi
 ################################################################################
 # BUILD IMAGE
 
-FROM eclipse-temurin:25-jdk-alpine
+FROM eclipse-temurin:25.0.4_7-jre-alpine-3.24
 
 # add non-root user to run the app
 # https://spring.io/guides/gs/spring-boot-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests -Drevisi
 ################################################################################
 # BUILD IMAGE
 
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25.0.4_7-jre-alpine
 
 # Upgrade OS packages to apply latest security patches
 RUN apk upgrade --no-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests -Drevisi
 
 FROM eclipse-temurin:25-jre-alpine
 
+# Upgrade OS packages to apply latest security patches
+RUN apk upgrade --no-cache
+
 # add non-root user to run the app
 # https://spring.io/guides/gs/spring-boot-docker
 RUN addgroup -S spring && adduser -S spring -G spring

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn --quiet --batch-mode --update-snapshots --fail-fast -DskipTests -Drevisi
 ################################################################################
 # BUILD IMAGE
 
-FROM eclipse-temurin:25.0.4_7-jre-alpine-3.24
+FROM eclipse-temurin:25-jre-alpine
 
 # add non-root user to run the app
 # https://spring.io/guides/gs/spring-boot-docker

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ $ mvn test
 
 ### Create a Docker image
 
-To build a Docker image, run this from the project root:
+To build a Docker image for local testing, run the following command from the project root:
 
 ```bash
-$ docker build -f Dockerfile -t fairdatapoint:local .
+docker build --build-arg PROJECT_VERSION=<local-version> --tag <local-tag> .
 ```
 
 ## Security


### PR DESCRIPTION
- switch eclipse-temurin base image from jdk to jre and pin the version (but not the alpine version, to prevent dependabot from getting confused)
- run apk upgrade for the runtime image
- prevent dependabot from suggesting major image upgrades for eclipse-temurin