### PR TITLE
Docker pin maven image version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
       - "dependencies"
     allow:
       # don't do major upgrades
-      - dependency-name: "eclipse-temurin:*"
+      - dependency-name: "*eclipse-temurin*"
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 # BUILD JAR
 
-FROM maven:3-eclipse-temurin-25-alpine AS builder
+FROM maven:3.9.16-eclipse-temurin-25-alpine AS builder
 
 WORKDIR /builder
 


### PR DESCRIPTION
Pin the image for the dockerfile's build stage and prevent major version upgrades from dependabot.